### PR TITLE
test: node-repair simulation rig scaffold (WIP, stacked on POC)

### DIFF
--- a/pkg/controllers/disruption/repair_simulation_axes_test.go
+++ b/pkg/controllers/disruption/repair_simulation_axes_test.go
@@ -125,28 +125,11 @@ func (c simCell) id() string {
 	return fmt.Sprintf("%s|%s|%s|%s|%s", c.help, c.corr, c.drain, c.strat, c.topo)
 }
 
-// skip encodes the degenerate cells (rules 1–3 from the design review): cells that are impossible or observationally
-// identical to another cell, so running them adds no signal.
-func (c simCell) skip() bool {
-	// Rule 1: topology is inert for an isolated fault (one node, one pool, one budget) — only `single` is meaningful.
-	if c.corr.isolated() && c.topo != topoSingle {
-		return true
-	}
-	// Rule 2: an ami-correlated burst is only observationally distinct under per-AMI topology; otherwise it collapses
-	// into a nodepool-wide (single) or zonal burst.
-	if c.corr == corrAMI && c.topo != topoPerAMI {
-		return true
-	}
-	// Rule 3: if nothing is ever drained, the PDB values collapse to the no-PDB baseline. The original is never
-	// terminated when we replace-first AND the replacement never becomes healthy (the pre-spin gate never clears).
-	replacementNeverHealthy := c.help == helpNoLaunchFail || c.help == helpNoUnhealthyInDwell
-	if c.strat == stratReplaceFirst && replacementNeverHealthy && c.drain != drainYesNoPDB {
-		return true
-	}
-	return false
-}
-
-// enumerateCells returns every non-degenerate cell in the cross product.
+// enumerateCells returns the FULL cross product — every cell is an explicit, authoritative entry. There is deliberately
+// no skip()/pruning predicate: which cells are degenerate is not a static property of a cell (a cell that collapses for
+// the breaker may not for restraint), so we do not *assert* degeneracy up front — we run every cell and let identical
+// metric rows reveal degeneracy *empirically* (see the collapse report in repair_simulation_test.go). This also avoids
+// leaking implementation mechanism into enumeration and can't silently drop a cell that's live for some implementation.
 func enumerateCells() []simCell {
 	var cells []simCell
 	for _, h := range []helpTruth{helpYes, helpNoLaunchFail, helpNoUnhealthyInDwell, helpNoUnhealthyAfterDwell, helpNoWorkloadBroken} {
@@ -154,10 +137,7 @@ func enumerateCells() []simCell {
 			for _, d := range []drainability{drainYesNoPDB, drainYesPDB, drainNoPDBBlock, drainNoKubeletDead} {
 				for _, s := range []strategy{stratReplaceFirst, stratTerminateFirst} {
 					for _, t := range []topology{topoSingle, topoPerAZ, topoPerAMI} {
-						cell := simCell{help: h, corr: corr, drain: d, strat: s, topo: t}
-						if !cell.skip() {
-							cells = append(cells, cell)
-						}
+						cells = append(cells, simCell{help: h, corr: corr, drain: d, strat: s, topo: t})
 					}
 				}
 			}

--- a/pkg/controllers/disruption/repair_simulation_axes_test.go
+++ b/pkg/controllers/disruption/repair_simulation_axes_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+import "fmt"
+
+// The node-repair scenario space is a cross product of five axes. A simCell is one point in it. Every axis value is
+// expressed in end-user-observable terms so the cases stay implementation-agnostic (black box) across options.
+
+// Axis 1 — ground truth: will repairing actually help? This is the scoring oracle AND the replacement fault model.
+type helpTruth int
+
+const (
+	helpYes                  helpTruth = iota // replacement comes up healthy and stays healthy → repair helps
+	helpNoLaunchFail                          // replacement never launches (ICE/capacity) → repair can't help
+	helpNoUnhealthyInDwell                    // replacement boots Ready, re-flagged WITHIN the success dwell
+	helpNoUnhealthyAfterDwell                 // replacement healthy PAST the dwell (scored "proven"), then fails
+	helpNoWorkloadBroken                      // node Ready+healthy to Karpenter, but the workload still fails (blind spot)
+)
+
+func (h helpTruth) String() string {
+	switch h {
+	case helpYes:
+		return "help"
+	case helpNoLaunchFail:
+		return "launchfail"
+	case helpNoUnhealthyInDwell:
+		return "reflag-in-dwell"
+	case helpNoUnhealthyAfterDwell:
+		return "reflag-after-dwell"
+	case helpNoWorkloadBroken:
+		return "workload-broken"
+	}
+	return "?"
+}
+
+// helps reports whether repairing genuinely resolves the fault (the oracle direction: minimize TTM when true,
+// minimize disruption/cp-calls when false). Note workload-broken is observationally healthy but does NOT help.
+func (h helpTruth) helps() bool { return h == helpYes }
+
+// Axis 2 — is the failure correlated on a specific failure domain (and thus a burst), or an isolated single fault?
+type correlation int
+
+const (
+	corrNone   correlation = iota // isolated single fault
+	corrZone                      // burst shares a zone
+	corrAMI                       // burst shares an AMI (only distinct under per-AMI topology)
+	corrPolicy                    // burst shares a policy/condition (a bad detector)
+)
+
+func (c correlation) String() string {
+	return [...]string{"isolated", "zone", "ami", "policy"}[c]
+}
+
+// isolated reports whether this is a single-node fault (no burst to pace).
+func (c correlation) isolated() bool { return c == corrNone }
+
+// Axis 3 — can the node be drained, and do PDBs participate?
+type drainability int
+
+const (
+	drainYesNoPDB      drainability = iota // kubelet alive, no PDB → drains freely (baseline)
+	drainYesPDB                            // kubelet alive, permissive PDB → drains, PDB paces eviction
+	drainNoPDBBlock                        // kubelet alive, restrictive PDB → drain stalls/bounded
+	drainNoKubeletDead                     // Ready=Unknown → forceful, drain skipped, PDBs irrelevant
+)
+
+func (d drainability) String() string {
+	return [...]string{"drain", "drain+pdb", "pdb-block", "kubelet-dead"}[d]
+}
+
+// hasPDB reports whether the scenario places a PodDisruptionBudget on the workload.
+func (d drainability) hasPDB() bool { return d == drainYesPDB || d == drainNoPDBBlock }
+
+// Axis 4 — replacement strategy, derived from capacity posture (how repair acts, not whether it helps).
+type strategy int
+
+const (
+	stratReplaceFirst   strategy = iota // headroom → pre-spin a replacement, then terminate
+	stratTerminateFirst                 // no headroom (reserved/static) → delete-only, reactive refill
+)
+
+func (s strategy) String() string {
+	return [...]string{"replace-first", "terminate-first"}[s]
+}
+
+// Axis 5 — the customer's NodePool topology, which decides how restraint's domains and the per-NodePool budget line up.
+type topology int
+
+const (
+	topoSingle topology = iota // one NodePool spanning all AZs + AMIs
+	topoPerAZ                  // one NodePool per AZ (pool ≡ zone)
+	topoPerAMI                 // one NodePool per AMI/arch variant (pool ≡ ami)
+)
+
+func (t topology) String() string {
+	return [...]string{"single", "per-az", "per-ami"}[t]
+}
+
+// simCell is one scenario in the cross product.
+type simCell struct {
+	help  helpTruth
+	corr  correlation
+	drain drainability
+	strat strategy
+	topo  topology
+}
+
+// id is a stable, compact identifier for the cell (used for ordering and report rows).
+func (c simCell) id() string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s", c.help, c.corr, c.drain, c.strat, c.topo)
+}
+
+// skip encodes the degenerate cells (rules 1–3 from the design review): cells that are impossible or observationally
+// identical to another cell, so running them adds no signal.
+func (c simCell) skip() bool {
+	// Rule 1: topology is inert for an isolated fault (one node, one pool, one budget) — only `single` is meaningful.
+	if c.corr.isolated() && c.topo != topoSingle {
+		return true
+	}
+	// Rule 2: an ami-correlated burst is only observationally distinct under per-AMI topology; otherwise it collapses
+	// into a nodepool-wide (single) or zonal burst.
+	if c.corr == corrAMI && c.topo != topoPerAMI {
+		return true
+	}
+	// Rule 3: if nothing is ever drained, the PDB values collapse to the no-PDB baseline. The original is never
+	// terminated when we replace-first AND the replacement never becomes healthy (the pre-spin gate never clears).
+	replacementNeverHealthy := c.help == helpNoLaunchFail || c.help == helpNoUnhealthyInDwell
+	if c.strat == stratReplaceFirst && replacementNeverHealthy && c.drain != drainYesNoPDB {
+		return true
+	}
+	return false
+}
+
+// enumerateCells returns every non-degenerate cell in the cross product.
+func enumerateCells() []simCell {
+	var cells []simCell
+	for _, h := range []helpTruth{helpYes, helpNoLaunchFail, helpNoUnhealthyInDwell, helpNoUnhealthyAfterDwell, helpNoWorkloadBroken} {
+		for _, corr := range []correlation{corrNone, corrZone, corrAMI, corrPolicy} {
+			for _, d := range []drainability{drainYesNoPDB, drainYesPDB, drainNoPDBBlock, drainNoKubeletDead} {
+				for _, s := range []strategy{stratReplaceFirst, stratTerminateFirst} {
+					for _, t := range []topology{topoSingle, topoPerAZ, topoPerAMI} {
+						cell := simCell{help: h, corr: corr, drain: d, strat: s, topo: t}
+						if !cell.skip() {
+							cells = append(cells, cell)
+						}
+					}
+				}
+			}
+		}
+	}
+	return cells
+}

--- a/pkg/controllers/disruption/repair_simulation_rig_test.go
+++ b/pkg/controllers/disruption/repair_simulation_rig_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+// Rig for the node-repair simulation matrix: the end-to-end machinery each cell runs through, and the swappable
+// implementation OPTIONS. The rig deliberately steps a candidate all the way through drain + termination (not the
+// ExpectNodeClaimsCascadeDeletion shortcut the focused unit suites use) so PodDisruptionBudgets, the termination grace
+// period, and forceful-vs-graceful drain actually execute and are measurable — which is what makes Axis 3 real.
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nodehealth "sigs.k8s.io/karpenter/pkg/controllers/node/health"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
+	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations" //nolint:staticcheck
+)
+
+// maxDrainSteps bounds the drain/termination loop so a wedged (PDB-blocked, never-forceful) node can't spin forever;
+// hitting it is itself observable (the node never terminated).
+const maxDrainSteps = 40
+
+// EventuallyExpectNodeDrainedAndTerminated drives a node marked for deletion all the way through the real termination
+// state machine — cordon, drain (evicting pods through the eviction API, which honors PodDisruptionBudgets), forceful
+// deletion once the node's termination-grace-period deadline passes, then finalize — until the node object is gone or
+// maxDrainSteps is exhausted. It reconciles the termination controller and the eviction queue together, stepping the
+// clock each round, exactly as a running cluster would. Returns whether the node actually terminated and how many
+// pod evictions were issued (the PDB-paced drain cost).
+func EventuallyExpectNodeDrainedAndTerminated(
+	ctx context.Context,
+	c client.Client,
+	terminationController *termination.Controller,
+	evictionQueue *terminator.Queue,
+	stepClock func(time.Duration),
+	node *corev1.Node,
+) (terminated bool, evictions int) {
+	GinkgoHelper()
+	// Marking the node for deletion is what the disruption queue (or the breaker) does when it decides to remove the
+	// candidate; the termination controller only acts on a node with a deletion timestamp + the termination finalizer.
+	if node.DeletionTimestamp.IsZero() {
+		if err := client.IgnoreNotFound(c.Delete(ctx, node)); err != nil {
+			return false, evictions
+		}
+	}
+	for i := 0; i < maxDrainSteps; i++ {
+		fresh := &corev1.Node{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(node), fresh); err != nil {
+			return true, evictions // node is gone → terminated
+		}
+		// One termination pass: taints + starts/continues the drain (enqueues evictable pods, or force-deletes past TGP).
+		ExpectObjectReconciled(ctx, c, terminationController, fresh)
+		// Process any pods the drain enqueued for eviction — this is where the PDB is honored (a blocking PDB fails the
+		// eviction and the pod stays, stalling the drain until the TGP deadline forces it).
+		if pods, err := nodeutils.GetPods(ctx, c, fresh.Name); err == nil {
+			for _, pod := range pods {
+				if evictionQueue.Has(pod) {
+					ExpectObjectReconciled(ctx, c, evictionQueue, pod)
+					evictions++
+				}
+			}
+		}
+		stepClock(2 * termination.MinDrainTime)
+	}
+	// Exhausted the budget without the node disappearing → not terminated (e.g. a fully-blocking PDB with no TGP).
+	if err := c.Get(ctx, client.ObjectKeyFromObject(node), &corev1.Node{}); err != nil {
+		return true, evictions
+	}
+	return false, evictions
+}
+
+// simImpl is one swappable implementation OPTION under test. The cases are identical across options; only impl varies.
+//   - name: report column.
+//   - reconcileDecision: run ONE "should I repair, and how" pass (a disruption-controller reconcile for the repair
+//     method options; a health-controller reconcile over the unhealthy nodes for the breaker).
+// Teardown (drain + terminate) is shared across options via EventuallyExpectNodeDrainedAndTerminated.
+type simImpl struct {
+	name              string
+	reconcileDecision func()
+}
+
+// buildBreakerImpl restores the pre-repair behavior: the node.health controller with its hardcoded 20% breaker. It is
+// a Node-keyed reconciler that force-deletes unhealthy NodeClaims directly (no pre-spin, no budget), gated only by the
+// breaker. Comparison-only — not registered in production.
+func buildBreakerImpl(healthController *nodehealth.Controller, unhealthyNodes func() []*corev1.Node) simImpl {
+	return simImpl{
+		name: "breaker-20pct",
+		reconcileDecision: func() {
+			for _, n := range unhealthyNodes() {
+				ExpectObjectReconciled(ctx, env.Client, healthController, n)
+			}
+		},
+	}
+}
+
+// NOTE: the restraint-based options (budget+restraint, pinned/unpinned) plug into this seam from the voluntary-repair
+// POC layer that stacks ON TOP of this rig — they reference disruption.NewRepair, which does not exist at this base.
+// The base rig deliberately carries only the implementation-agnostic cases + the breaker baseline (node.health exists
+// here). See buildBreakerImpl above; each implementation branch adds its own simImpl builder.
+
+// buildTerminationRig constructs the shared drain/termination machinery (eviction queue + termination controller) the
+// runner uses to tear down every candidate, for every option.
+func buildTerminationRig() (*termination.Controller, *terminator.Queue) {
+	evictionQueue := terminator.NewQueue(env.Client, recorder)
+	tc := termination.NewController(env.Clock, env.Client, cloudProvider, terminator.NewTerminator(env.Clock, env.Client, evictionQueue, recorder), recorder)
+	return tc, evictionQueue
+}
+
+// unhealthyNodesForBreaker lists nodes carrying a RepairPolicy-matching unhealthy condition (the breaker's input set).
+func unhealthyNodesForBreaker(policies func() []corev1.NodeConditionType) func() []*corev1.Node {
+	return func() []*corev1.Node {
+		var out []*corev1.Node
+		for _, n := range ExpectNodes(ctx, env.Client) {
+			for _, ct := range policies() {
+				if cond := nodeutils.GetCondition(n, ct); cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
+					out = append(out, n)
+					break
+				}
+			}
+		}
+		return out
+	}
+}

--- a/pkg/controllers/disruption/repair_simulation_rig_test.go
+++ b/pkg/controllers/disruption/repair_simulation_rig_test.go
@@ -16,127 +16,257 @@ limitations under the License.
 
 package disruption_test
 
-// Rig for the node-repair simulation matrix: the end-to-end machinery each cell runs through, and the swappable
-// implementation OPTIONS. The rig deliberately steps a candidate all the way through drain + termination (not the
-// ExpectNodeClaimsCascadeDeletion shortcut the focused unit suites use) so PodDisruptionBudgets, the termination grace
-// period, and forceful-vs-graceful drain actually execute and are measurable — which is what makes Axis 3 real.
+// The simulation runner + fault models + implementation options.
+//
+// Each cell runs an ITERATED loop (decision → advance fault model on any fresh replacements → drain+terminate marked
+// nodes → step clock) to steady state, on a single stepped clock — so the differentiating behavior (multi-pass
+// pre-spin/dwell/terminate, re-flag loops, burst pacing) and decision latency are actually exercised, not just the
+// shared teardown. The teardown drives the REAL termination state machine so PDB/TGP/forceful drain execute and are
+// measurable.
+//
+// At this base (main), the only runnable option is the 20% breaker (node.health exists here; NewRepair does not). The
+// budget+restraint options (pinned/unpinned) plug into `simImpl` from the voluntary-repair POC layer stacked above.
 
 import (
 	"context"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	nodehealth "sigs.k8s.io/karpenter/pkg/controllers/node/health"
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination"
 	"sigs.k8s.io/karpenter/pkg/controllers/node/termination/terminator"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
-	. "sigs.k8s.io/karpenter/pkg/test/expectations" //nolint:staticcheck
 )
 
-// maxDrainSteps bounds the drain/termination loop so a wedged (PDB-blocked, never-forceful) node can't spin forever;
-// hitting it is itself observable (the node never terminated).
-const maxDrainSteps = 40
+const (
+	simTick       = time.Minute      // clock advance per decision round
+	simMaxRounds  = 40               // bound on decision rounds (episode never converging shows as wedged/unmitigated)
+	simMaxDrain   = 40               // bound on the per-node drain loop
+	simBurst      = 5                // nodes in a correlated burst
+	simFiller     = 10               // healthy filler nodes per pool (so the unhealthy fraction is realistic)
+	simToleration = 30 * time.Minute // RepairPolicy toleration used across the matrix
+	repairCond    = corev1.NodeConditionType("BadNode")
+)
 
-// EventuallyExpectNodeDrainedAndTerminated drives a node marked for deletion all the way through the real termination
-// state machine — cordon, drain (evicting pods through the eviction API, which honors PodDisruptionBudgets), forceful
-// deletion once the node's termination-grace-period deadline passes, then finalize — until the node object is gone or
-// maxDrainSteps is exhausted. It reconciles the termination controller and the eviction queue together, stepping the
-// clock each round, exactly as a running cluster would. Returns whether the node actually terminated and how many
-// pod evictions were issued (the PDB-paced drain cost).
-func EventuallyExpectNodeDrainedAndTerminated(
-	ctx context.Context,
-	c client.Client,
-	terminationController *termination.Controller,
-	evictionQueue *terminator.Queue,
-	stepClock func(time.Duration),
-	node *corev1.Node,
-) (terminated bool, evictions int) {
-	GinkgoHelper()
-	// Marking the node for deletion is what the disruption queue (or the breaker) does when it decides to remove the
-	// candidate; the termination controller only acts on a node with a deletion timestamp + the termination finalizer.
-	if node.DeletionTimestamp.IsZero() {
-		if err := client.IgnoreNotFound(c.Delete(ctx, node)); err != nil {
-			return false, evictions
-		}
-	}
-	for i := 0; i < maxDrainSteps; i++ {
-		fresh := &corev1.Node{}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(node), fresh); err != nil {
-			return true, evictions // node is gone → terminated
-		}
-		// One termination pass: taints + starts/continues the drain (enqueues evictable pods, or force-deletes past TGP).
-		ExpectObjectReconciled(ctx, c, terminationController, fresh)
-		// Process any pods the drain enqueued for eviction — this is where the PDB is honored (a blocking PDB fails the
-		// eviction and the pod stays, stalling the drain until the TGP deadline forces it).
-		if pods, err := nodeutils.GetPods(ctx, c, fresh.Name); err == nil {
-			for _, pod := range pods {
-				if evictionQueue.Has(pod) {
-					ExpectObjectReconciled(ctx, c, evictionQueue, pod)
-					evictions++
-				}
-			}
-		}
-		stepClock(2 * termination.MinDrainTime)
-	}
-	// Exhausted the budget without the node disappearing → not terminated (e.g. a fully-blocking PDB with no TGP).
-	if err := c.Get(ctx, client.ObjectKeyFromObject(node), &corev1.Node{}); err != nil {
-		return true, evictions
-	}
-	return false, evictions
-}
-
-// simImpl is one swappable implementation OPTION under test. The cases are identical across options; only impl varies.
-//   - name: report column.
-//   - reconcileDecision: run ONE "should I repair, and how" pass (a disruption-controller reconcile for the repair
-//     method options; a health-controller reconcile over the unhealthy nodes for the breaker).
-// Teardown (drain + terminate) is shared across options via EventuallyExpectNodeDrainedAndTerminated.
+// simImpl is one swappable implementation OPTION. reconcileDecision runs ONE decision pass; the runner iterates it.
 type simImpl struct {
 	name              string
 	reconcileDecision func()
 }
 
-// buildBreakerImpl restores the pre-repair behavior: the node.health controller with its hardcoded 20% breaker. It is
-// a Node-keyed reconciler that force-deletes unhealthy NodeClaims directly (no pre-spin, no budget), gated only by the
-// breaker. Comparison-only — not registered in production.
-func buildBreakerImpl(healthController *nodehealth.Controller, unhealthyNodes func() []*corev1.Node) simImpl {
+// fleet is the objects a cell's scenario created, retained so the runner can drive + observe them.
+type fleet struct {
+	nodePools []*v1.NodePool
+	nodes     []*corev1.Node    // the originally-faulted nodes
+	claims    []*v1.NodeClaim
+	podLabels map[string]string // workload selector (for PDB matching), or nil
+}
+
+// --- drain measurement -------------------------------------------------------------------------------------------
+
+// drainOutcome is what a single node teardown produced.
+type drainOutcome struct {
+	terminated bool
+	evictions  int
+}
+
+// drainAndTerminate drives a node marked for deletion through the REAL termination state machine — cordon, drain
+// (evicting pods through the eviction API, which honors PodDisruptionBudgets), forceful deletion once the node's
+// termination-grace-period deadline passes, then finalize — reconciling the termination controller + eviction queue
+// and stepping the clock until the node is gone or simMaxDrain is exhausted. It is a MEASUREMENT instrument (returns
+// data), deliberately not named Expect*/Eventually* and not an assert-or-fail helper: a node that never terminates
+// (e.g. a fully-blocking PDB) is a result we want to record (terminated=false), not a spec failure.
+func drainAndTerminate(ctx context.Context, tc *termination.Controller, eq *terminator.Queue, node *corev1.Node) drainOutcome {
+	out := drainOutcome{}
+	// The node-termination controller only drains a node that has the termination finalizer; without it a Delete would
+	// vanish the node instantly (no drain). Ensure it before deleting so the drain path actually runs.
+	if !lo.Contains(node.Finalizers, v1.TerminationFinalizer) {
+		stored := node.DeepCopy()
+		node.Finalizers = append(node.Finalizers, v1.TerminationFinalizer)
+		_ = env.Client.Patch(ctx, node, client.MergeFrom(stored))
+	}
+	// Count the workload pods on the node at teardown start — the observable disruption, whether they end up gracefully
+	// evicted or force-deleted past the TGP (the eviction-queue counter alone misses forceful deletions).
+	if pods, err := nodeutils.GetPods(ctx, env.Client, node.Name); err == nil {
+		out.evictions += len(pods)
+	}
+	if node.DeletionTimestamp.IsZero() {
+		if err := client.IgnoreNotFound(env.Client.Delete(ctx, node)); err != nil {
+			return out
+		}
+	}
+	for i := 0; i < simMaxDrain; i++ {
+		fresh := &corev1.Node{}
+		if err := env.Client.Get(ctx, client.ObjectKeyFromObject(node), fresh); err != nil {
+			out.terminated = true
+			return out
+		}
+		// Direct Reconcile (not ExpectObjectReconciled): this is a measurement instrument, so a transient reconcile
+		// error must not fail the spec — a node that can't finish terminating is a RESULT (recorded as not-terminated).
+		_, _ = tc.Reconcile(ctx, fresh)
+		if pods, err := nodeutils.GetPods(ctx, env.Client, fresh.Name); err == nil {
+			for _, pod := range pods {
+				if eq.Has(pod) {
+					_, _ = eq.Reconcile(ctx, pod)
+				}
+			}
+		}
+		env.Clock.Step(2 * termination.MinDrainTime)
+	}
+	if err := env.Client.Get(ctx, client.ObjectKeyFromObject(node), &corev1.Node{}); err != nil {
+		out.terminated = true
+	}
+	return out
+}
+
+// buildTerminationRig constructs the shared drain/termination machinery the runner uses to tear down every candidate.
+func buildTerminationRig() (*termination.Controller, *terminator.Queue) {
+	eq := terminator.NewQueue(env.Client, recorder)
+	tc := termination.NewController(env.Clock, env.Client, cloudProvider, terminator.NewTerminator(env.Clock, env.Client, eq, recorder), recorder)
+	return tc, eq
+}
+
+// --- breaker option (runnable at this base; node.health exists on main) ------------------------------------------
+
+func buildBreakerImpl(hc *nodehealth.Controller) simImpl {
 	return simImpl{
 		name: "breaker-20pct",
 		reconcileDecision: func() {
-			for _, n := range unhealthyNodes() {
-				ExpectObjectReconciled(ctx, env.Client, healthController, n)
+			// The health controller is Node-keyed; feed it every node still carrying the repair condition.
+			for _, n := range ExpectNodes(ctx, env.Client) {
+				if cond := nodeutils.GetCondition(n, repairCond); cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
+	_, _ = hc.Reconcile(ctx, n)
+				}
 			}
 		},
 	}
 }
 
-// NOTE: the restraint-based options (budget+restraint, pinned/unpinned) plug into this seam from the voluntary-repair
-// POC layer that stacks ON TOP of this rig — they reference disruption.NewRepair, which does not exist at this base.
-// The base rig deliberately carries only the implementation-agnostic cases + the breaker baseline (node.health exists
-// here). See buildBreakerImpl above; each implementation branch adds its own simImpl builder.
+// --- fleet setup -------------------------------------------------------------------------------------------------
 
-// buildTerminationRig constructs the shared drain/termination machinery (eviction queue + termination controller) the
-// runner uses to tear down every candidate, for every option.
-func buildTerminationRig() (*termination.Controller, *terminator.Queue) {
-	evictionQueue := terminator.NewQueue(env.Client, recorder)
-	tc := termination.NewController(env.Clock, env.Client, cloudProvider, terminator.NewTerminator(env.Clock, env.Client, evictionQueue, recorder), recorder)
-	return tc, evictionQueue
+// zonesFor / amisFor spread a burst across the domains a correlation shares (or not).
+func poolCountFor(c simCell) int {
+	switch c.topo {
+	case topoPerAZ, topoPerAMI:
+		return 3
+	default:
+		return 1
+	}
 }
 
-// unhealthyNodesForBreaker lists nodes carrying a RepairPolicy-matching unhealthy condition (the breaker's input set).
-func unhealthyNodesForBreaker(policies func() []corev1.NodeConditionType) func() []*corev1.Node {
-	return func() []*corev1.Node {
-		var out []*corev1.Node
-		for _, n := range ExpectNodes(ctx, env.Client) {
-			for _, ct := range policies() {
-				if cond := nodeutils.GetCondition(n, ct); cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
-					out = append(out, n)
-					break
-				}
+// setupFleet realizes a cell as cluster objects and returns them. It marks the fault (past toleration) so the decision
+// loop can act immediately.
+func setupFleet(c simCell) fleet {
+	f := fleet{}
+	nPools := poolCountFor(c)
+	for i := 0; i < nPools; i++ {
+		var np *v1.NodePool
+		if c.strat == stratTerminateFirst {
+			np = test.StaticNodePool(v1.NodePool{Spec: v1.NodePoolSpec{Replicas: lo.ToPtr(int64(simBurst))}})
+		} else {
+			np = test.NodePool()
+		}
+		ExpectApplied(ctx, env.Client, np)
+		f.nodePools = append(f.nodePools, np)
+	}
+
+	// Healthy filler so the unhealthy FRACTION is realistic — otherwise every pool is 100% unhealthy and the 20% breaker
+	// always freezes, collapsing the whole matrix. With filler, an isolated fault is a small fraction (breaker acts) and
+	// a correlated burst pushes the pool over the threshold (breaker freezes) — the behavior we want to measure.
+	for _, pool := range f.nodePools {
+		for i := 0; i < simFiller; i++ {
+			nc, n := test.NodeClaimAndNode(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1.NodePoolLabelKey: pool.Name, v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: "test-zone-1a",
+			}}})
+			ExpectApplied(ctx, env.Client, nc, n)
+			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{n}, []*v1.NodeClaim{nc})
+		}
+	}
+
+	count := 1
+	if !c.corr.isolated() {
+		count = simBurst
+	}
+	// A workload label so PDB cases can select the pods.
+	if c.drain.hasPDB() {
+		f.podLabels = map[string]string{"sim-workload": "app"}
+	}
+	for i := 0; i < count; i++ {
+		pool := f.nodePools[i%len(f.nodePools)]
+		zone := "test-zone-1a"
+		if c.corr == corrZone || c.topo == topoPerAZ {
+			zone = []string{"test-zone-1a", "test-zone-1b", "test-zone-1c"}[i%3]
+			if c.topo == topoPerAZ {
+				zone = []string{"test-zone-1a", "test-zone-1b", "test-zone-1c"}[(i % len(f.nodePools))]
 			}
 		}
-		return out
+		nc, n := test.NodeClaimAndNode(v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{v1.TerminationFinalizer}, // so a decision's Delete lingers (deletion timestamp) and flows through drain, as in prod
+			Labels: map[string]string{
+				v1.NodePoolLabelKey: pool.Name, v1.CapacityTypeLabelKey: v1.CapacityTypeOnDemand, corev1.LabelTopologyZone: zone,
+			}}})
+		ExpectApplied(ctx, env.Client, nc, n)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, []*corev1.Node{n}, []*v1.NodeClaim{nc})
+		bindWorkload(n, f.podLabels)
+		f.nodes = append(f.nodes, n)
+		f.claims = append(f.claims, nc)
 	}
+	if c.drain.hasPDB() {
+		mu := intstr.FromString("100%")
+		if c.drain == drainNoPDBBlock {
+			mu = intstr.FromInt(0)
+		}
+		ExpectApplied(ctx, env.Client, test.PodDisruptionBudget(test.PDBOptions{Labels: f.podLabels, MaxUnavailable: &mu}))
+	}
+	// Inject the fault, then advance past toleration so it is immediately actionable.
+	for _, n := range f.nodes {
+		markFault(c, n)
+	}
+	env.Clock.Step(simToleration + time.Minute)
+	return f
+}
+
+// bindWorkload attaches a ReplicaSet-owned pod (so termination has something to drain and reactive provisioning has a
+// pod to replace). labels, if set, are stamped for PDB matching.
+func bindWorkload(n *corev1.Node, labels map[string]string) {
+	rs := test.ReplicaSet()
+	ExpectApplied(ctx, env.Client, rs)
+	Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+	pod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{
+		Labels: labels,
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rs.Name, UID: rs.UID, Controller: lo.ToPtr(true), BlockOwnerDeletion: lo.ToPtr(true)}},
+	}})
+	ExpectApplied(ctx, env.Client, pod)
+	ExpectManualBinding(ctx, env.Client, pod, n)
+	ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
+}
+
+// markFault stamps the repair-matching condition. kubelet-dead is represented as Ready=Unknown (drain can't proceed
+// gracefully); otherwise the node stays Ready with the BadNode condition False.
+func markFault(c simCell, n *corev1.Node) {
+	n = ExpectExists(ctx, env.Client, n)
+	ready := corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "KubeletReady",
+		LastHeartbeatTime: metav1.NewTime(env.Clock.Now()), LastTransitionTime: metav1.NewTime(env.Clock.Now())}
+	if c.drain == drainNoKubeletDead {
+		// kubelet-dead: Ready=Unknown (node controller lost the heartbeat) → graceful drain can't proceed.
+		ready = corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionUnknown, Reason: "NodeStatusUnknown",
+			LastHeartbeatTime: metav1.NewTime(env.Clock.Now()), LastTransitionTime: metav1.NewTime(env.Clock.Now())}
+	}
+	n.Status.Phase = corev1.NodeRunning
+	n.Status.Conditions = []corev1.NodeCondition{
+		ready,
+		{Type: repairCond, Status: corev1.ConditionFalse, Reason: "SimFault",
+			LastHeartbeatTime: metav1.NewTime(env.Clock.Now()), LastTransitionTime: metav1.NewTime(env.Clock.Now())},
+	}
+	ExpectApplied(ctx, env.Client, n)
+	ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
 }

--- a/pkg/controllers/disruption/repair_simulation_runner_test.go
+++ b/pkg/controllers/disruption/repair_simulation_runner_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	nodehealth "sigs.k8s.io/karpenter/pkg/controllers/node/health"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/test"
+	. "sigs.k8s.io/karpenter/pkg/test/expectations"
+	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
+)
+
+// runCell runs one cell under one option to steady state on a single stepped clock, returning observable metrics.
+// The loop: decision pass → reactively provision replacements for pending pods → apply the cell's fault model to those
+// fresh replacements (healthy / re-flag / launch-fail / workload-broken) → drain+terminate marked nodes → step clock.
+func runCell(impl simImpl, c simCell) simMetrics {
+	tc, eq := buildTerminationRig()
+	cloudProvider.Reset()
+	onset := env.Clock.Now()
+	f := setupFleet(c)
+	origClaims := claimNameSet(f.claims)
+
+	// launch-fail: every replacement Create fails (ICE/capacity), for the whole run.
+	if c.help == helpNoLaunchFail {
+		cloudProvider.AllowedCreateCalls = 0
+	}
+
+	m := simMetrics{outcome: outcomeDeclined}
+	acted := false
+	var mitigatedAt *time.Time
+
+	for round := 0; round < simMaxRounds; round++ {
+		impl.reconcileDecision()
+
+		// A decision removes a node by marking its NODECLAIM for deletion (that's what both the breaker and the repair
+		// method do). In production the nodeclaim lifecycle controller then deletes the Node; the rig bridges that here
+		// and drives the REAL node-termination drain (PDB/TGP honored) rather than a cascade shortcut.
+		for _, nc := range ExpectNodeClaims(ctx, env.Client) {
+			if !nc.DeletionTimestamp.IsZero() {
+				acted = true
+				if node := nodeForClaim(nc); node != nil {
+					out := drainAndTerminate(ctx, tc, eq, node)
+					m.disruptedPods += out.evictions
+					if !out.terminated {
+						m.outcome = outcomeWedged
+					}
+				}
+				// Finalize the (already deleting) nodeclaim so it doesn't linger as a phantom in-flight repair.
+				ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nc)
+			}
+		}
+
+		// Reactive provisioning: any pending pods get a replacement (unless launch is failing).
+		if pending := pendingPods(); len(pending) > 0 {
+			ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, prov, pending...)
+			applyFaultModel(c, origClaims)
+		}
+
+		// True mitigation = the originally-faulted nodes are gone and no repair-eligible unhealthy node remains
+		// (a healthy replacement is carrying the workload). Only meaningful when repair can actually help.
+		if mitigatedAt == nil && c.help == helpYes && faultResolved(f) {
+			t := env.Clock.Now()
+			mitigatedAt = &t
+		}
+		if episodeSettled(c, f) {
+			break
+		}
+		env.Clock.Step(simTick)
+	}
+
+	m.cpWrites = len(cloudProvider.CreateCalls) + len(cloudProvider.DeleteCalls)
+	m.outcome, m.timeToMitigation = classify(c, f, acted, mitigatedAt, onset, m.outcome)
+	return m
+}
+
+// classify turns the loop's observations into an outcome + TTM, keeping wedged (from the drain loop) sticky.
+func classify(c simCell, f fleet, acted bool, mitigatedAt *time.Time, onset time.Time, cur simOutcome) (simOutcome, *time.Duration) {
+	if cur == outcomeWedged {
+		return outcomeWedged, nil
+	}
+	if c.help == helpYes {
+		if mitigatedAt != nil {
+			d := mitigatedAt.Sub(onset)
+			return outcomeMitigated, &d
+		}
+		return outcomeUnmitigated, nil // genuine fault never resolved (frozen breaker, or launch-fail)
+	}
+	// Repair could not truly help. Acting at all is waste; declining is correct.
+	if acted {
+		return outcomeChurned, nil
+	}
+	return outcomeDeclined, nil
+}
+
+// applyFaultModel realizes the ground-truth behavior on freshly-provisioned replacement NodeClaims (those not in the
+// original set). It is what makes a cell a false-positive vs a true fault, in observable terms.
+func applyFaultModel(c simCell, orig map[string]bool) {
+	fresh := lo.Filter(ExpectNodeClaims(ctx, env.Client), func(nc *v1.NodeClaim, _ int) bool {
+		return !orig[nc.Name] && nc.StatusConditions().Get(v1.ConditionTypeInitialized).IsFalse()
+	})
+	if len(fresh) == 0 {
+		return
+	}
+	nodes := make([]*corev1.Node, 0, len(fresh))
+	for _, nc := range fresh {
+		nodes = append(nodes, test.NodeClaimLinkedNode(nc))
+	}
+	// Bring the replacements up as healthy nodes first (the common prefix of every non-launch-fail model).
+	ExpectApplied(ctx, env.Client, lo.Map(nodes, func(n *corev1.Node, _ int) client.Object { return n })...)
+	ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, env.Clock, nodeStateController, nodeClaimStateController, nodes, fresh)
+
+	switch c.help {
+	case helpNoUnhealthyInDwell, helpNoUnhealthyAfterDwell:
+		// The systematic false positive / bad-component re-fires on the fresh replacement.
+		for _, n := range nodes {
+			markFault(c, n)
+		}
+	case helpYes, helpNoWorkloadBroken:
+		// Replacement is Ready+healthy to Karpenter. (workload-broken is the blind spot: identical observable, but the
+		// oracle in classify() never counts it as resolved.)
+	}
+}
+
+// --- observation helpers -----------------------------------------------------------------------------------------
+
+func nodeForClaim(nc *v1.NodeClaim) *corev1.Node {
+	for _, n := range ExpectNodes(ctx, env.Client) {
+		if nc.Status.ProviderID != "" && n.Spec.ProviderID == nc.Status.ProviderID {
+			return n
+		}
+		if nc.Status.NodeName != "" && n.Name == nc.Status.NodeName {
+			return n
+		}
+	}
+	return nil
+}
+
+func claimNameSet(claims []*v1.NodeClaim) map[string]bool {
+	m := map[string]bool{}
+	for _, nc := range claims {
+		m[nc.Name] = true
+	}
+	return m
+}
+
+func pendingPods() []*corev1.Pod {
+	list := &corev1.PodList{}
+	_ = env.Client.List(ctx, list)
+	var out []*corev1.Pod
+	for i := range list.Items {
+		p := &list.Items[i]
+		if p.Spec.NodeName == "" && p.DeletionTimestamp.IsZero() {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// faultResolved: none of the originally-faulted nodes remain AND nothing currently carries the repair condition.
+func faultResolved(f fleet) bool {
+	for _, n := range f.nodes {
+		if err := env.Client.Get(ctx, client.ObjectKeyFromObject(n), &corev1.Node{}); err == nil {
+			return false // an original fault node still exists
+		}
+	}
+	for _, n := range ExpectNodes(ctx, env.Client) {
+		if cond := nodeutils.GetCondition(n, repairCond); cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
+			return false // something still unhealthy
+		}
+	}
+	return true
+}
+
+// episodeSettled: nothing left to do — no unhealthy repair-eligible node and no node mid-termination.
+func episodeSettled(c simCell, f fleet) bool {
+	for _, n := range ExpectNodes(ctx, env.Client) {
+		if !n.DeletionTimestamp.IsZero() {
+			return false
+		}
+		if cond := nodeutils.GetCondition(n, repairCond); cond.Status == corev1.ConditionFalse || cond.Status == corev1.ConditionUnknown {
+			// still unhealthy: settled only if repair can't/won't act further this run — let the round cap catch it.
+			return false
+		}
+	}
+	return true
+}
+
+var _ = Describe("Repair/Simulation", func() {
+	var healthController *nodehealth.Controller
+	BeforeEach(func() {
+		cloudProvider.RepairPolicy = []cloudprovider.RepairPolicy{
+			{ConditionType: repairCond, ConditionStatus: corev1.ConditionFalse, TolerationDuration: simToleration},
+			{ConditionType: corev1.NodeReady, ConditionStatus: corev1.ConditionUnknown, TolerationDuration: simToleration},
+		}
+		healthController = nodehealth.NewController(env.Client, cloudProvider, env.Clock, recorder)
+	})
+
+	// The runnable options at THIS base. Restraint (pinned/unpinned) is appended from the POC layer stacked above.
+	options := func() []simImpl { return []simImpl{buildBreakerImpl(healthController)} }
+
+	for _, cell := range enumerateCells() {
+		cell := cell
+		It("cell "+cell.id(), func() {
+			for _, impl := range options() {
+				recordResult(cell, impl.name, runCell(impl, cell))
+			}
+		})
+	}
+})

--- a/pkg/controllers/disruption/repair_simulation_test.go
+++ b/pkg/controllers/disruption/repair_simulation_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+// Node-repair behavior simulation / regression matrix.
+//
+// This is the "trunk": a black-box cross-product of end-user scenarios, scored on three observable metrics. The
+// implementation under test is a swappable OPTION (see the seam below) — the same cases run against the 20% breaker,
+// budget+restraint (replacement pinned to failure domain), and budget+restraint (unpinned). Running the matrix across
+// options and reading the numbers is the "simulation"; the winning option keeps these as its regression suite.
+//
+// The scenario space is a cross product of five axes (repair_simulation_axes.go). The fault MODEL — how a pre-spun
+// replacement behaves — is what makes a cell a false-positive vs a true fault, expressed only in observable terms
+// (the replacement comes up healthy / gets re-flagged / never launches), never by reaching into the implementation.
+//
+// Metrics per (cell, option):
+//   - Time to mitigation: sim-clock from fault onset until the genuine fault is resolved (Inf if never).
+//   - Disruption incurred: summed Karpenter DisruptionCost of terminated nodes (pod-eviction-cost weighted).
+//   - Cloud-provider calls: launches (+ deletes) the option drove — the load proxy.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// simResult is one (cell, option) measurement.
+type simResult struct {
+	cell   simCell
+	option string
+	m      simMetrics
+}
+
+// simMetrics are the three observable outcomes. timeToMitigation is nil when the genuine fault was never mitigated
+// (or when the cell has no genuine fault to mitigate — Axis1 != helpYes).
+type simMetrics struct {
+	timeToMitigation *time.Duration
+	disruptionCost   float64
+	cloudProviderCalls int
+}
+
+// simReport accumulates every (cell, option) result across the matrix so it can be written out once at the end.
+var simReport []simResult
+
+// recordResult appends a measurement to the global report.
+func recordResult(cell simCell, option string, m simMetrics) {
+	simReport = append(simReport, simResult{cell: cell, option: option, m: m})
+}
+
+// formatSimReport renders the accumulated results as a markdown table, grouped by cell, one column per option per
+// metric. It is emitted at the end of the suite so the whole matrix can be reviewed as actual numbers.
+func formatSimReport(results []simResult) string {
+	if len(results) == 0 {
+		return "(no simulation results recorded)\n"
+	}
+	// Stable ordering: by cell id, then option.
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].cell.id() != results[j].cell.id() {
+			return results[i].cell.id() < results[j].cell.id()
+		}
+		return results[i].option < results[j].option
+	})
+	var b strings.Builder
+	b.WriteString("| cell | option | time-to-mitigation | disruption-cost | cp-calls |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, r := range results {
+		ttm := "n/a"
+		if r.m.timeToMitigation != nil {
+			ttm = r.m.timeToMitigation.String()
+		} else if r.cell.help == helpYes {
+			ttm = "NEVER" // a genuine fault that should have been mitigated but wasn't
+		}
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %.1f | %d |\n",
+			r.cell.id(), r.option, ttm, r.m.disruptionCost, r.m.cloudProviderCalls))
+	}
+	return b.String()
+}
+
+// ReportAfterSuite writes the full matrix of numbers once every cell x option has run.
+var _ = ReportAfterSuite("node-repair simulation matrix", func(_ Report) {
+	if len(simReport) == 0 {
+		return
+	}
+	GinkgoWriter.Printf("\n===== NODE REPAIR SIMULATION MATRIX (%d results) =====\n%s\n", len(simReport), formatSimReport(simReport))
+})

--- a/pkg/controllers/disruption/repair_simulation_test.go
+++ b/pkg/controllers/disruption/repair_simulation_test.go
@@ -16,21 +16,22 @@ limitations under the License.
 
 package disruption_test
 
-// Node-repair behavior simulation / regression matrix.
+// Node-repair behavior simulation / regression matrix — metrics + reporting.
 //
-// This is the "trunk": a black-box cross-product of end-user scenarios, scored on three observable metrics. The
-// implementation under test is a swappable OPTION (see the seam below) — the same cases run against the 20% breaker,
-// budget+restraint (replacement pinned to failure domain), and budget+restraint (unpinned). Running the matrix across
-// options and reading the numbers is the "simulation"; the winning option keeps these as its regression suite.
+// This is the "trunk": a black-box cross product of end-user scenarios, scored on OBSERVABLE metrics, run across
+// swappable implementation OPTIONS (the same cells run against the 20% breaker at this base, and against
+// budget+restraint pinned/unpinned from the POC layer stacked on top). Running the matrix across options and reading
+// the numbers is the "simulation"; the winning option keeps these cells as its regression suite.
 //
-// The scenario space is a cross product of five axes (repair_simulation_axes.go). The fault MODEL — how a pre-spun
-// replacement behaves — is what makes a cell a false-positive vs a true fault, expressed only in observable terms
-// (the replacement comes up healthy / gets re-flagged / never launches), never by reaching into the implementation.
-//
-// Metrics per (cell, option):
-//   - Time to mitigation: sim-clock from fault onset until the genuine fault is resolved (Inf if never).
-//   - Disruption incurred: summed Karpenter DisruptionCost of terminated nodes (pod-eviction-cost weighted).
-//   - Cloud-provider calls: launches (+ deletes) the option drove — the load proxy.
+// Metrics are deliberately observable (not Karpenter-internal): a repair implementation must not be graded on its own
+// objective function.
+//   - timeToMitigation: sim-clock from fault onset until the genuine fault is truly resolved (a healthy replacement is
+//     carrying the workload). nil when there is no genuine fault to resolve (help != helpYes) or it was never resolved
+//     — disambiguated by `outcome`, never by an overloaded nil.
+//   - disruptedPods: pods actually evicted/deleted during the run (the workload-facing disruption cost, observable —
+//     NOT Karpenter's internal DisruptionCost heuristic).
+//   - cpWrites: cloud-provider write ATTEMPTS (Create+Delete), counting failed launches too, so an ICE/capacity
+//     retry-storm shows up as call inflation rather than being hidden by a success-only count.
 
 import (
 	"fmt"
@@ -41,6 +42,26 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
+// simOutcome names what actually happened, so a never-terminated (wedged) run is never confused with a correct
+// decision not to repair (declined) or with a genuine miss (unmitigated).
+type simOutcome string
+
+const (
+	outcomeMitigated   simOutcome = "mitigated"    // genuine fault resolved: healthy replacement carrying the workload
+	outcomeDeclined    simOutcome = "declined"     // repair took no disrupting action (correct when repair can't help)
+	outcomeChurned     simOutcome = "churned"      // repair disrupted node(s) but the fault was NOT resolved (waste)
+	outcomeWedged      simOutcome = "wedged"       // repair tried but could not complete (e.g. PDB-blocked, never drained)
+	outcomeUnmitigated simOutcome = "unmitigated"  // genuine fault, repair acted, but replacement never came up healthy
+)
+
+// simMetrics are the observable outcomes of running one cell under one option.
+type simMetrics struct {
+	timeToMitigation *time.Duration
+	disruptedPods    int
+	cpWrites         int
+	outcome          simOutcome
+}
+
 // simResult is one (cell, option) measurement.
 type simResult struct {
 	cell   simCell
@@ -48,55 +69,89 @@ type simResult struct {
 	m      simMetrics
 }
 
-// simMetrics are the three observable outcomes. timeToMitigation is nil when the genuine fault was never mitigated
-// (or when the cell has no genuine fault to mitigate — Axis1 != helpYes).
-type simMetrics struct {
-	timeToMitigation *time.Duration
-	disruptionCost   float64
-	cloudProviderCalls int
-}
-
-// simReport accumulates every (cell, option) result across the matrix so it can be written out once at the end.
+// simReport accumulates every (cell, option) result. NOTE: for the real matrix run this is fed from DescribeTable
+// entries; because the suite can run in parallel processes, aggregate reporting is done per-process via GinkgoWriter
+// and this global is only authoritative within a single process. (Cross-process aggregation, if needed, reads the
+// per-process dumps.)
 var simReport []simResult
 
-// recordResult appends a measurement to the global report.
 func recordResult(cell simCell, option string, m simMetrics) {
 	simReport = append(simReport, simResult{cell: cell, option: option, m: m})
 }
 
-// formatSimReport renders the accumulated results as a markdown table, grouped by cell, one column per option per
-// metric. It is emitted at the end of the suite so the whole matrix can be reviewed as actual numbers.
+func ttmString(r simResult) string {
+	if r.m.timeToMitigation != nil {
+		return r.m.timeToMitigation.String()
+	}
+	return "-"
+}
+
+// formatSimReport renders every measurement as a markdown table (one row per cell per option).
 func formatSimReport(results []simResult) string {
 	if len(results) == 0 {
 		return "(no simulation results recorded)\n"
 	}
-	// Stable ordering: by cell id, then option.
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].cell.id() != results[j].cell.id() {
-			return results[i].cell.id() < results[j].cell.id()
+	sorted := append([]simResult(nil), results...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].option != sorted[j].option {
+			return sorted[i].option < sorted[j].option
 		}
-		return results[i].option < results[j].option
+		return sorted[i].cell.id() < sorted[j].cell.id()
 	})
 	var b strings.Builder
-	b.WriteString("| cell | option | time-to-mitigation | disruption-cost | cp-calls |\n")
-	b.WriteString("|---|---|---|---|---|\n")
-	for _, r := range results {
-		ttm := "n/a"
-		if r.m.timeToMitigation != nil {
-			ttm = r.m.timeToMitigation.String()
-		} else if r.cell.help == helpYes {
-			ttm = "NEVER" // a genuine fault that should have been mitigated but wasn't
-		}
-		b.WriteString(fmt.Sprintf("| %s | %s | %s | %.1f | %d |\n",
-			r.cell.id(), r.option, ttm, r.m.disruptionCost, r.m.cloudProviderCalls))
+	b.WriteString("| option | cell | outcome | time-to-mitigation | disrupted-pods | cp-writes |\n")
+	b.WriteString("|---|---|---|---|---|---|\n")
+	for _, r := range sorted {
+		b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %d | %d |\n",
+			r.option, r.cell.id(), r.m.outcome, ttmString(r), r.m.disruptedPods, r.m.cpWrites))
 	}
 	return b.String()
 }
 
-// ReportAfterSuite writes the full matrix of numbers once every cell x option has run.
+// formatCollapseReport reveals degeneracy EMPIRICALLY: within each option, cells whose full metric tuple is identical
+// are grouped. Each group of size > 1 is a set of cells that this implementation could not distinguish — the honest,
+// measured version of what a static skip() predicate would only have claimed. (A group that is a singleton for one
+// option but collapsed for another is itself a finding.)
+func formatCollapseReport(results []simResult) string {
+	byOption := map[string]map[string][]string{} // option -> metric-signature -> []cellID
+	for _, r := range results {
+		sig := fmt.Sprintf("%s|ttm=%s|pods=%d|cpw=%d", r.m.outcome, ttmString(r), r.m.disruptedPods, r.m.cpWrites)
+		if byOption[r.option] == nil {
+			byOption[r.option] = map[string][]string{}
+		}
+		byOption[r.option][sig] = append(byOption[r.option][sig], r.cell.id())
+	}
+	options := make([]string, 0, len(byOption))
+	for o := range byOption {
+		options = append(options, o)
+	}
+	sort.Strings(options)
+
+	var b strings.Builder
+	b.WriteString("Empirically collapsed cell groups (identical metrics ⇒ this option can't tell them apart):\n")
+	for _, o := range options {
+		var groups [][]string
+		for _, cells := range byOption[o] {
+			if len(cells) > 1 {
+				sort.Strings(cells)
+				groups = append(groups, cells)
+			}
+		}
+		sort.SliceStable(groups, func(i, j int) bool { return len(groups[i]) > len(groups[j]) })
+		b.WriteString(fmt.Sprintf("  [%s] %d collapsed group(s):\n", o, len(groups)))
+		for _, g := range groups {
+			b.WriteString(fmt.Sprintf("    - %d cells: %s\n", len(g), strings.Join(g, ", ")))
+		}
+	}
+	return b.String()
+}
+
+// ReportAfterEach dumps this process's accumulated matrix + collapse analysis once the suite finishes. Per-process
+// (see simReport note) so it is parallel-safe.
 var _ = ReportAfterSuite("node-repair simulation matrix", func(_ Report) {
 	if len(simReport) == 0 {
 		return
 	}
-	GinkgoWriter.Printf("\n===== NODE REPAIR SIMULATION MATRIX (%d results) =====\n%s\n", len(simReport), formatSimReport(simReport))
+	GinkgoWriter.Printf("\n===== NODE REPAIR SIMULATION MATRIX (%d results) =====\n%s\n%s\n",
+		len(simReport), formatSimReport(simReport), formatCollapseReport(simReport))
 })

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -94,7 +94,9 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(test.WithCRDs(coreapis.CRDs...), test.WithCRDs(v1alpha1.CRDs...))
+	// The status.providerID field index is required by the node.health (breaker) controller's NodeClaimForNode lookup,
+	// which the repair simulation drives as a comparison option. Additive; harmless to the other disruption tests.
+	env = test.NewEnvironment(test.WithCRDs(coreapis.CRDs...), test.WithCRDs(v1alpha1.CRDs...), test.WithFieldIndexers(test.NodeClaimProviderIDFieldIndexer(ctx)))
 	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	clusterCost = cost.NewClusterCost(ctx, cloudProvider, env.Client)


### PR DESCRIPTION
Stacked on the voluntary-repair POC (#20) so this diff shows **only the simulation rig**, not the voluntary-repair commits (those live on the POC branch).

Black-box scenario matrix for node repair: implementation-agnostic cases scored on observable metrics (time-to-mitigation, DisruptionCost, cloud-provider calls), run across swappable options (20% breaker / budget+restraint pinned / unpinned).

**In this scaffold (no numbers yet — runner still to come):**
- `repair_simulation_axes_test.go` — 5-axis cross product (help-oracle / correlation domain / drain-ability incl. PDBs / replacement strategy / nodepool topology) + degeneracy skip rules + `enumerateCells()`.
- `repair_simulation_rig_test.go` — `EventuallyExpectNodeDrainedAndTerminated` (drives the real termination state machine so PDB/TGP/forceful drain actually execute + are measurable), the shared termination rig, and the option seam.
- `repair_simulation_test.go` — metrics + `ReportAfterSuite` table emitter.
- `pkg/controllers/node/health/*` — 20% breaker restored as a comparison-only baseline.

**Not yet wired:** the per-cell runner, the fault-model setup per axis, and the real replacement-pinned-to-zone toggle. Draft / for-read.