### PR TITLE
chore(controllers): standardize Name() to a string literal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@ A file for [guiding coding agents](https://agents.md/).
 - KWOK reference provider (local dev): `kwok/`
 - E2E suites: `test/suites/`
 
+## Controllers
+
+- Every controller (a type implementing `controller.Controller`, i.e. with a
+  `Register(ctx, manager) error` method and registered in
+  `pkg/controllers/controllers.go`) exposes its name via:
+
+  ```go
+  func (c *Controller) Name() string { return "<literal>" }
+  ```
+
+  Use a plain string literal — not a `Sprintf`, a concatenation, or a struct
+  field. The literal must match the name passed to `.Named(...)` during
+  registration. Controller names are used only for the `controller` dimension
+  on metrics and for logging, so a literal is sufficient and keeps the full set
+  of names scrapeable directly from source.
+
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -117,6 +117,10 @@ func NewController(kubeClient client.Client) *Controller {
 	}
 }
 
+func (c *Controller) Name() string {
+	return "dynamicresources.deviceallocation"
+}
+
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	c.Hydrate(ctx)
 


### PR DESCRIPTION
## Convention

Every Karpenter controller (a type implementing `controller.Controller` — it has a `Register(ctx, manager) error` method and is registered in `pkg/controllers/controllers.go`) should expose its name via:

```go
func (c *Controller) Name() string { return "<string literal>" }
```

The literal must match the name passed to `.Named(...)` at registration time.

### Why

Controller names are used only for the `controller` dimension on metrics and for logging. Keeping each name a plain string literal in the controller's own file (rather than a `Sprintf`, a concatenation, or a struct field) means the full set of controller names can be scraped directly from source — useful for generating metrics/log documentation.

## What changed

- **`pkg/controllers/dynamicresources/deviceallocation`** — was the only genuine controller missing a `Name()` method. Added `func (c *Controller) Name() string { return "dynamicresources.deviceallocation" }`, matching the existing `.Named("dynamicresources.deviceallocation")` in `Register`. Runtime name is unchanged.
- **`AGENTS.md`** — documented the convention under a new "Controllers" section.

All other controllers already conformed (each returns a plain string literal). Non-controller types that also happen to have `Name() string` — instance-type filters, lifecycle hooks, state helpers like `StateNode`, cloud providers — were intentionally left untouched.

## Controllers that can't use a literal

None. Every controller's name is static and expressible as a literal.

## Verification

`go build ./...` passes.