### PR TITLE
chore(controllers): follow-up to #3268 — register deviceallocation via c.Name()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@ A file for [guiding coding agents](https://agents.md/).
 - KWOK reference provider (local dev): `kwok/`
 - E2E suites: `test/suites/`
 
+## Controllers
+
+- Every controller (a type implementing `controller.Controller`, i.e. with a
+  `Register(ctx, manager) error` method and registered in
+  `pkg/controllers/controllers.go`) exposes its name via:
+
+  ```go
+  func (c *Controller) Name() string { return "<literal>" }
+  ```
+
+  Use a plain string literal — not a `Sprintf`, a concatenation, or a struct
+  field. The literal must match the name passed to `.Named(...)` during
+  registration. Controller names are used only for the `controller` dimension
+  on metrics and for logging, so a literal is sufficient and keeps the full set
+  of names scrapeable directly from source.
+
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,22 +29,6 @@ A file for [guiding coding agents](https://agents.md/).
 - KWOK reference provider (local dev): `kwok/`
 - E2E suites: `test/suites/`
 
-## Controllers
-
-- Every controller (a type implementing `controller.Controller`, i.e. with a
-  `Register(ctx, manager) error` method and registered in
-  `pkg/controllers/controllers.go`) exposes its name via:
-
-  ```go
-  func (c *Controller) Name() string { return "<literal>" }
-  ```
-
-  Use a plain string literal — not a `Sprintf`, a concatenation, or a struct
-  field. The literal must match the name passed to `.Named(...)` during
-  registration. Controller names are used only for the `controller` dimension
-  on metrics and for logging, so a literal is sufficient and keeps the full set
-  of names scrapeable directly from source.
-
 ## Issue and PR Guidelines
 
 - Never create an issue.

--- a/pkg/controllers/dynamicresources/deviceallocation/controller.go
+++ b/pkg/controllers/dynamicresources/deviceallocation/controller.go
@@ -308,7 +308,7 @@ func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
 		return fmt.Errorf("adding hydration runnable, %w", err)
 	}
 	return controllerruntime.NewControllerManagedBy(m).
-		Named("dynamicresources.deviceallocation").
+		Named(c.Name()).
 		For(&resourcev1.ResourceClaim{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: utilscontroller.LinearScaleReconciles(utilscontroller.CPUCount(ctx), minReconciles, maxReconciles)}).
 		Complete(c)


### PR DESCRIPTION
Follow-up to the merged #3268 — filed against the fork (not upstream).

- **deviceallocation** (@ryan-mist nit): register via `.Named(c.Name())` instead of repeating the `"dynamicresources.deviceallocation"` literal, so `Name()` is the single source.

(The AGENTS.md `## Controllers` section stays — the earlier comment was soliciting reviewer opinion, not a request to cut.)
