### PR TITLE
chore(breaking): standardize the reason metric label to lowercase values

### DIFF
--- a/pkg/controllers/disruption/helpers.go
+++ b/pkg/controllers/disruption/helpers.go
@@ -300,10 +300,10 @@ func BuildDisruptionBudgetMapping(ctx context.Context, cluster *state.Cluster, c
 		allowedDisruptions := nodePool.MustGetAllowedDisruptions(clk, numNodes[nodePool.Name], reason)
 		disruptionBudgetMapping[nodePool.Name] = lo.Max([]int{allowedDisruptions - disrupting[nodePool.Name], 0})
 		NodePoolAllowedDisruptions.Set(float64(allowedDisruptions), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: strings.ToLower(string(reason)),
 		})
 		NodePoolNodesConsumingBudgets.Set(float64(disrupting[nodePool.Name]), map[string]string{
-			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: string(reason),
+			metrics.NodePoolLabel: nodePool.Name, metrics.ReasonLabel: strings.ToLower(string(reason)),
 		})
 		if numNodes[nodePool.Name] != 0 && allowedDisruptions == 0 {
 			recorder.Publish(disruptionevents.NodePoolBlockedForDisruptionReason(nodePool, reason))

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -165,7 +165,7 @@ func (q *Queue) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconci
 		})
 		DisruptionQueueFailuresTotal.Add(float64(len(failedLaunches)), map[string]string{
 			decisionLabel:          string(cmd.Decision()),
-			metrics.ReasonLabel:    pretty.ToSnakeCase(string(cmd.Reason())),
+			metrics.ReasonLabel:    strings.ToLower(string(cmd.Reason())),
 			ConsolidationTypeLabel: string(cmd.Decision()),
 		})
 		stateNodes := lo.Map(cmd.Candidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode })
@@ -246,7 +246,7 @@ func (q *Queue) waitOrTerminate(ctx context.Context, cmd *Command) (err error) {
 			consolidationPolicy = pretty.ToSnakeCase(string(cmd.Candidates[i].NodePool.Spec.Disruption.ConsolidationPolicy))
 		}
 		labels := map[string]string{
-			metrics.ReasonLabel:              pretty.ToSnakeCase(string(cmd.Reason())),
+			metrics.ReasonLabel:              strings.ToLower(string(cmd.Reason())),
 			metrics.NodePoolLabel:            cmd.Candidates[i].NodeClaim.Labels[v1.NodePoolLabelKey],
 			metrics.CapacityTypeLabel:        cmd.Candidates[i].NodeClaim.Labels[v1.CapacityTypeLabelKey],
 			metrics.ConsolidationPolicyLabel: consolidationPolicy,


### PR DESCRIPTION
The `reason` dimension is emitted three different ways across disruption metrics — raw TitleCase (`Underutilized`) in the NodePool budget gauges, `pretty.ToSnakeCase` in the queue metrics, and `strings.ToLower` elsewhere. This unifies them all to `strings.ToLower` so `reason` has one consistent, documentable value set (prereq for enumerating its well-known values in the metrics docs).

**Breaking change:** `karpenter_nodepool_allowed_disruptions` and `karpenter_nodepool_nodes_consuming_budgets` now emit lowercase reason values (`underutilized` vs `Underutilized`). The other emissions already lowercased their single-word values, so those are unchanged; the `ToSnakeCase`→`ToLower` swap is output-preserving for the current single-word reasons.

Upgrade-guide entry is a companion change on the provider website (this repo has no docs).