### PR TITLE
feat: correlated-failure restraint via optimistic clawback (POC, off 1/4)

### DIFF
--- a/kwok/charts/crds/karpenter.sh_nodepools.yaml
+++ b/kwok/charts/crds/karpenter.sh_nodepools.yaml
@@ -294,6 +294,8 @@ spec:
                                     rule: self != "karpenter.sh/nodepool"
                                   - message: label "kubernetes.io/hostname" is restricted
                                     rule: self != "kubernetes.io/hostname"
+                                  - message: label domain "karpenter.kwok.sh" is restricted
+                                    rule: self in ["karpenter.kwok.sh/kwoknodeclass", "karpenter.kwok.sh/instance-cpu", "karpenter.kwok.sh/instance-memory", "karpenter.kwok.sh/instance-family", "karpenter.kwok.sh/instance-size"] || !self.find("^([^/]+)").endsWith("karpenter.kwok.sh")
                               minValues:
                                 description: |-
                                   This field is ALPHA and can be dropped or replaced at any time

--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -47,7 +47,7 @@ const (
 
 // Karpenter specific annotations
 const (
-	DoNotDisruptAnnotationKey                  = apis.Group + "/do-not-disrupt"
+	DoNotDisruptAnnotationKey = apis.Group + "/do-not-disrupt"
 	// DoNotRepairAnnotationKey vetoes voluntary node repair on a node, distinct from do-not-disrupt.
 	DoNotRepairAnnotationKey                   = apis.Group + "/do-not-repair"
 	ProviderCompatibilityAnnotationKey         = apis.CompatibilityGroup + "/provider"
@@ -59,6 +59,12 @@ const (
 	// scheduled to this NodeClaim. The initialization controller can gate on these drivers having published their
 	// ResourceSlices before marking the node initialized.
 	DRADriversAnnotationKey = apis.Group + "/requested-dra-drivers"
+	// LaunchContextAnnotationKey records launch-time provenance for a NodeClaim: why it was created (LaunchCause) and,
+	// for a disruption replacement, which NodeClaim it superseded. It is the durable, crash-surviving marker the
+	// correlated-failure repair loop reads to identify its own in-flight replacements — and the failure domain they
+	// belong to — from cluster state alone, without an in-memory ledger. Its value is the JSON of a LaunchContext.
+	// POC: this rides in an annotation so it needs no CRD change; it is a candidate to promote to spec.launchContext.
+	LaunchContextAnnotationKey = apis.Group + "/launch-context"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1/nodeclaim_status.go
+++ b/pkg/apis/v1/nodeclaim_status.go
@@ -33,6 +33,13 @@ const (
 	ConditionTypeInstanceTerminating  = "InstanceTerminating"
 	ConditionTypeConsistentStateFound = "ConsistentStateFound"
 	ConditionTypeDisruptionReason     = "DisruptionReason"
+	// ConditionTypeRepairCredited / ConditionTypeRepairClawedBack are the terminal outcomes the clawback controller
+	// stamps on a repair-launched replacement (LaunchContext.Cause=Unhealthy). Credited: the replacement held Ready, so
+	// its failure domains were widened (optimistic). ClawedBack: the replacement re-broke inside the clawback window, so
+	// its domains were slammed shut and backed off. They make the controller idempotent (credit/claw back once) and its
+	// decision auditable straight from the NodeClaim.
+	ConditionTypeRepairCredited   = "RepairCredited"
+	ConditionTypeRepairClawedBack = "RepairClawedBack"
 )
 
 // NodeClaimStatus defines the observed state of NodeClaim

--- a/pkg/apis/v1/nodepool.go
+++ b/pkg/apis/v1/nodepool.go
@@ -120,7 +120,7 @@ type Disruption struct {
 type Budget struct {
 	// reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
 	// Otherwise, this will apply to each reason defined.
-	// allowed reasons are Underutilized, Empty, and Drifted.
+	// allowed reasons are Underutilized, Empty, Drifted, and Unhealthy.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
 	// +listType=set

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -104,9 +104,13 @@ func NewControllers(
 	disruptionQueue := disruption.NewQueue(kubeClient, recorder, cluster, clock, p)
 	npState := nodepoolhealth.NewState()
 	clusterCost := cost.NewClusterCost(ctx, cloudProvider, kubeClient)
+	// Shared correlated-failure restraint dial: repair (reader, inside the disruption controller) paces admission
+	// against it, and the clawback controller (writer) widens/slams it as replacements prove Ready or re-break. One
+	// instance so both see the same per-domain width/cooldown.
+	repairWindow := disruption.NewWindow(clock.Now)
 	controllers := []controller.Controller{
 		p, evictionQueue, disruptionQueue,
-		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue, clusterCost),
+		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster, disruptionQueue, clusterCost, disruption.WithRepairWindow(repairWindow)),
 		provisioning.NewPodController(kubeClient, p, cluster),
 		provisioning.NewNodeController(kubeClient, p),
 		nodepoolhash.NewController(kubeClient, cloudProvider),
@@ -160,6 +164,14 @@ func NewControllers(
 				status.WithHistogramBuckets(prometheus.ExponentialBuckets(0.5, 2, 15)), // 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192
 				status.WithLabels(append(lo.Map(cloudProvider.GetSupportedNodeClasses(), func(obj status.Object, _ int) string { return v1.NodeClassLabelKey(object.GVK(obj).GroupKind()) }), v1.NodePoolLabelKey, v1.NodeInitializedLabelKey)...)),
 		)
+	}
+
+	// The clawback controller is repair's correlated-failure restraint writer (optimistic + clawback): it widens the
+	// shared window when a repair replacement holds Ready and slams it shut if the replacement re-breaks inside the
+	// clawback window. Gated identically to the repair method — a cloud provider with repair policies and the
+	// NodeRepair feature gate on.
+	if len(cloudProvider.RepairPolicies()) != 0 && options.FromContext(ctx).FeatureGates.NodeRepair {
+		controllers = append(controllers, disruption.NewClawbackController(clock, kubeClient, cloudProvider, repairWindow))
 	}
 
 	if options.FromContext(ctx).FeatureGates.StaticCapacity {

--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -74,7 +74,8 @@ type Controller struct {
 const pollingPeriod = 10 * time.Second
 
 type ControllerOptions struct {
-	methods []Method
+	methods      []Method
+	repairWindow *Window
 }
 
 func WithMethods(methods ...Method) option.Function[ControllerOptions] {
@@ -83,12 +84,24 @@ func WithMethods(methods ...Method) option.Function[ControllerOptions] {
 	}
 }
 
+// WithRepairWindow injects the shared correlated-failure restraint Window into the default repair method, so repair
+// (reader) and the clawback controller (writer) pace against the same per-domain dial. Ignored when WithMethods
+// overrides the method set (the caller then supplies its own Repair).
+func WithRepairWindow(w *Window) option.Function[ControllerOptions] {
+	return func(o *ControllerOptions) {
+		o.repairWindow = w
+	}
+}
+
 func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provisioning.Provisioner,
 	cp cloudprovider.CloudProvider, recorder events.Recorder, cluster *state.Cluster, queue *Queue, clusterCost *cost.ClusterCost, opts ...option.Function[ControllerOptions]) *Controller {
 
 	// Snapshot RepairPolicies() once and share it with both the Repair method and the candidate drain-bound gate.
 	repairPolicies := cp.RepairPolicies()
-	o := option.Resolve(append([]option.Function[ControllerOptions]{WithMethods(NewMethods(clk, cluster, kubeClient, provisioner, cp, recorder, queue, repairPolicies)...)}, opts...)...)
+	o := option.Resolve(opts...)
+	if o.methods == nil {
+		o.methods = NewMethods(clk, cluster, kubeClient, provisioner, cp, recorder, queue, repairPolicies, o.repairWindow)
+	}
 	return &Controller{
 		queue:          queue,
 		clock:          clk,
@@ -104,13 +117,14 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 	}
 }
 
-func NewMethods(clk clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner, cp cloudprovider.CloudProvider, recorder events.Recorder, queue *Queue, repairPolicies []cloudprovider.RepairPolicy) []Method {
+func NewMethods(clk clock.Clock, cluster *state.Cluster, kubeClient client.Client, provisioner *provisioning.Provisioner, cp cloudprovider.CloudProvider, recorder events.Recorder, queue *Queue, repairPolicies []cloudprovider.RepairPolicy, repairWindow *Window) []Method {
 	c := MakeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder, queue)
 	methods := []Method{}
 	// Repair runs first: fixing a fault outranks any discretionary rebalance. Only registered when a cloud provider
 	// defines repair policies and the NodeRepair feature gate is on, matching the old node.health controller's gating.
+	// repairWindow is the shared restraint dial the clawback controller writes; nil ⇒ repair builds a standalone one.
 	if len(repairPolicies) != 0 {
-		methods = append(methods, NewRepair(c, repairPolicies))
+		methods = append(methods, NewRepair(c, repairPolicies, repairWindow))
 	}
 	return append(methods, []Method{
 		// Delete empty nodes across all consolidation policies (WhenEmpty, WhenEmptyOrUnderutilized, Balanced).

--- a/pkg/controllers/disruption/queue.go
+++ b/pkg/controllers/disruption/queue.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/metrics"
 	"sigs.k8s.io/karpenter/pkg/operator/injection"
 	utilscontroller "sigs.k8s.io/karpenter/pkg/utils/controller"
+	"sigs.k8s.io/karpenter/pkg/utils/launchcontext"
 	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
 )
@@ -314,7 +315,14 @@ func (q *Queue) markDisrupted(ctx context.Context, cmd *Command) ([]*Candidate, 
 
 // createReplacementNodeClaims creates replacement NodeClaims
 func (q *Queue) createReplacementNodeClaims(ctx context.Context, cmd *Command) error {
-	nodeClaimNames, err := q.provisioner.CreateNodeClaims(ctx, lo.Map(cmd.Replacements, func(r *Replacement, _ int) *pscheduling.NodeClaim { return r.NodeClaim }), provisioning.WithReason(strings.ToLower(string(cmd.Reason()))))
+	// Stamp durable launch provenance on each replacement: its cause (the disruption reason) and — for a single-
+	// candidate command like repair — the NodeClaim it supersedes. This lets a disruption method (correlated-failure
+	// repair) identify its own in-flight replacements and dwell-tail from cluster state alone, no in-memory ledger.
+	lc := launchcontext.Context{Cause: launchcontext.ForReason(cmd.Reason())}
+	if len(cmd.Candidates) == 1 {
+		lc.Replaces = cmd.Candidates[0].NodeClaim.Name
+	}
+	nodeClaimNames, err := q.provisioner.CreateNodeClaims(ctx, lo.Map(cmd.Replacements, func(r *Replacement, _ int) *pscheduling.NodeClaim { return r.NodeClaim }), provisioning.WithReason(strings.ToLower(string(cmd.Reason()))), provisioning.WithLaunchContext(lc))
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/disruption/repair.go
+++ b/pkg/controllers/disruption/repair.go
@@ -28,6 +28,7 @@ import (
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	disruptionevents "sigs.k8s.io/karpenter/pkg/controllers/disruption/events"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -48,10 +49,17 @@ type Repair struct {
 	// reads the SAME snapshot (threaded from the controller) so the two never disagree about which policy governs a node.
 	repairPolicies []cloudprovider.RepairPolicy
 	ranks          map[int]int
+	// window is the shared correlated-failure restraint dial. Repair READS it (Admits) to pace admission per failure
+	// domain; the clawback controller WRITES it as replacements prove Ready or re-break. nil ⇒ a standalone Window
+	// (unshared), fine for a test Repair with no clawback controller.
+	window *Window
 }
 
-func NewRepair(c consolidation, repairPolicies []cloudprovider.RepairPolicy) *Repair {
-	return &Repair{consolidation: c, repairPolicies: repairPolicies, ranks: denseRanks(repairPolicies)}
+func NewRepair(c consolidation, repairPolicies []cloudprovider.RepairPolicy, window *Window) *Repair {
+	if window == nil {
+		window = NewWindow(c.clock.Now)
+	}
+	return &Repair{consolidation: c, repairPolicies: repairPolicies, ranks: denseRanks(repairPolicies), window: window}
 }
 
 // ShouldDisrupt is a predicate that filters candidates to nodes that have an unhealthy condition matching a
@@ -77,6 +85,11 @@ func (r *Repair) ShouldDisrupt(ctx context.Context, c *Candidate) bool {
 // ComputeCommands orders eligible candidates by the repair score and returns one replace-then-terminate command for the
 // highest-scoring candidate whose NodePool has budget. Only one command per pass, mirroring drift.
 func (r *Repair) ComputeCommands(ctx context.Context, disruptionBudgetMapping map[string]int, candidates ...*Candidate) ([]Command, error) {
+	// Correlated-failure restraint reads the shared Window against an in-flight count derived from cluster state (the
+	// durable DisruptionReason=Unhealthy condition). Computed once per pass; a candidate in several domains counts once
+	// per domain, so the min-width combine rule sees true per-domain concurrency.
+	inFlight := r.inFlightByDomain()
+
 	ranks := r.ranks
 	sort.SliceStable(candidates, func(i, j int) bool {
 		si, sj := r.score(candidates[i], ranks), r.score(candidates[j], ranks)
@@ -92,6 +105,13 @@ func (r *Repair) ComputeCommands(ctx context.Context, disruptionBudgetMapping ma
 
 	for _, candidate := range candidates {
 		if disruptionBudgetMapping[candidate.NodePool.Name] == 0 {
+			continue
+		}
+		// Correlated-failure restraint: even within budget, only admit this candidate if its failure domains
+		// (NodePool ∧ Zone ∧ Policy) have width headroom and are out of cooldown. A correlated burst collapses into
+		// shared domains that cold-start at width 1 → one probe first; the clawback controller widens only as probes
+		// prove Ready.
+		if !r.window.Admits(domainsOf(candidate), inFlight) {
 			continue
 		}
 		// Pre-spin the replacement; the queue terminates the original only once the replacement is healthy.
@@ -120,10 +140,35 @@ func (r *Repair) ComputeCommands(ctx context.Context, disruptionBudgetMapping ma
 	return []Command{}, nil
 }
 
-// score computes E = rank + age/τ − backoff. Age is time past toleration (post-eligibility), so a flakier signal's
-// longer toleration never leaks into its standing. Backoff pulls back a whole NodePool whose launches keep failing.
-// TODO: the backoff term is a placeholder — rip it out for the correlated-failure restraint model
-// (kubernetes-sigs/karpenter#3031, Dynamic Node Repair Circuit Breaking).
+// domainsOfStateNode derives a node's failure domains from observable cluster state (labels + node conditions), for the
+// state-derived in-flight count and the clawback controller — neither of which holds a Candidate.
+func domainsOfStateNode(n *state.StateNode) []failureDomain {
+	var node *corev1.Node
+	if n != nil {
+		node = n.Node
+	}
+	return domainsForNode(n.Labels()[v1.NodePoolLabelKey], n.Labels()[corev1.LabelTopologyZone], node)
+}
+
+// inFlightByDomain counts repair's in-flight probes per failure domain from cluster state — the same node walk as
+// BuildDisruptionBudgetMapping, but keyed on the durable DisruptionReason=Unhealthy condition instead of
+// NotReady/deletion. Reconstructed from the condition each pass, so it needs no in-memory probe ledger and is crash-safe
+// on resync (invariant: history is an optimization, never a correctness requirement). A node in several domains counts
+// once per domain, so the min-width combine rule sees the true concurrency in each.
+func (r *Repair) inFlightByDomain() map[failureDomain]int {
+	inflight := map[failureDomain]int{}
+	for _, n := range r.cluster.GetActiveDisruptions(v1.DisruptionReasonUnhealthy) {
+		for _, d := range domainsOfStateNode(n) {
+			inflight[d]++
+		}
+	}
+	return inflight
+}
+
+// score computes E = rank + age/τ. Age is time past toleration (post-eligibility), so a flakier signal's longer
+// toleration never leaks into its standing. Per-NodePool launch backoff is gone: correlated-failure restraint (the
+// shared Window, paced per failure domain by the clawback controller) subsumes the placeholder backoff this POC
+// originally carried here.
 func (r *Repair) score(c *Candidate, ranks map[int]int) float64 {
 	policy, cond := r.matchingPolicy(c.Node)
 	if policy == nil {
@@ -135,7 +180,7 @@ func (r *Repair) score(c *Candidate, ranks map[int]int) float64 {
 	if age < 0 {
 		age = 0
 	}
-	return rank + age.Minutes()/agingConstant.Minutes() - r.backoff(c.NodePool)
+	return rank + age.Minutes()/agingConstant.Minutes()
 }
 
 // denseRanks compresses the set of configured policy priorities into contiguous tiers (adjacent tiers one apart),
@@ -149,18 +194,6 @@ func denseRanks(policies []cloudprovider.RepairPolicy) map[int]int {
 		ranks[p] = i // lowest priority -> rank 0, ascending
 	}
 	return ranks
-}
-
-// backoff pulls a NodePool behind healthier pools when its replacements keep failing. A failed launch is almost never
-// node-specific (the AMI/capacity/config is bad for the whole pool), so it is keyed to the NodePool. The existing
-// NodeRegistrationHealthy signal is that per-pool "launches are failing" bit; when it is False, apply a one-tier pull.
-// TODO: rip out for the correlated-failure restraint model (kubernetes-sigs/karpenter#3031, Dynamic Node Repair
-// Circuit Breaking) — this single-bit per-pool pull is a placeholder for AZ/domain-aware restraint.
-func (r *Repair) backoff(np *v1.NodePool) float64 {
-	if np != nil && np.StatusConditions().Get(v1.ConditionTypeNodeRegistrationHealthy).IsFalse() {
-		return 1
-	}
-	return 0
 }
 
 // matchingPolicy returns the highest-priority RepairPolicy whose (type,status) matches an unhealthy condition on the

--- a/pkg/controllers/disruption/repair_clawback.go
+++ b/pkg/controllers/disruption/repair_clawback.go
@@ -1,0 +1,153 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"context"
+
+	"github.com/awslabs/operatorpkg/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+	"sigs.k8s.io/karpenter/pkg/utils/launchcontext"
+	nodeclaimutils "sigs.k8s.io/karpenter/pkg/utils/nodeclaim"
+)
+
+// ClawbackController is the writer side of correlated-failure restraint, in its optimistic + clawback mode. Repair
+// credits a probe optimistically — the shared Window widens a domain the instant a repair-launched replacement holds
+// Ready — and this controller watches that replacement for a re-break: if it goes unhealthy within the clawback window,
+// the credit was wrong, so the domain is slammed shut and backed off.
+//
+// The whole thing is stateless and event-driven, which is what the durable launch-context annotation buys: a repair
+// replacement carries "I was launched for repair" (LaunchContext.Cause=Unhealthy), *when* (CreationTimestamp), and
+// *where* (its own NodePool/zone labels). So the controller needs no in-memory probe ledger — a restart just keeps
+// reconciling the same annotated NodeClaims — and it records its verdict as durable, idempotent NodeClaim conditions
+// (RepairCredited / RepairClawedBack) so it never credits or claws back the same replacement twice.
+type ClawbackController struct {
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+	clock         clock.Clock
+	window        *Window
+}
+
+func NewClawbackController(clk clock.Clock, kubeClient client.Client, cp cloudprovider.CloudProvider, w *Window) *ClawbackController {
+	return &ClawbackController{kubeClient: kubeClient, cloudProvider: cp, clock: clk, window: w}
+}
+
+func (c *ClawbackController) Name() string { return "node.repair.clawback" }
+
+//nolint:gocyclo // straight-line reconcile: annotation guard + condition idempotency + one credit/clawback decision.
+func (c *ClawbackController) Reconcile(ctx context.Context, nodeClaim *v1.NodeClaim) (reconcile.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+	if !nodeclaimutils.IsManaged(nodeClaim, c.cloudProvider) || !nodeClaim.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+	// Only repair-launched replacements carry launch provenance we act on.
+	lc, ok := launchcontext.Get(nodeClaim)
+	if !ok || lc.Cause != launchcontext.CauseUnhealthy {
+		return reconcile.Result{}, nil
+	}
+	// Terminal: once clawed back, the verdict is final — nothing more to do (idempotent).
+	if nodeClaim.StatusConditions().Get(v1.ConditionTypeRepairClawedBack).IsTrue() {
+		return reconcile.Result{}, nil
+	}
+	if nodeClaim.Status.NodeName != "" {
+		ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("Node", klog.KRef("", nodeClaim.Status.NodeName)))
+	}
+
+	// Resolve the replacement's Node — its conditions carry both the health signal and the policy failure domain.
+	var node *corev1.Node
+	if nodeClaim.Status.NodeName != "" {
+		node = &corev1.Node{}
+		if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodeClaim.Status.NodeName}, node); err != nil {
+			// A reaped replacement Node is handled as its own repair candidate elsewhere; nothing to credit/claw here.
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+
+	age := c.clock.Now().Sub(nodeClaim.CreationTimestamp.Time)
+	// Failure domains from the replacement's OWN labels (nodepool, zone) plus its current unhealthy conditions (policy).
+	// Attributing to where the replacement actually landed is the learn-from-replacement rule: a bad zone cools its own
+	// zone, and a healthy replacement (no False conditions) widens only nodepool+zone.
+	domains := domainsForNode(nodeClaim.Labels[v1.NodePoolLabelKey], nodeClaim.Labels[corev1.LabelTopologyZone], node)
+	credited := nodeClaim.StatusConditions().Get(v1.ConditionTypeRepairCredited).IsTrue()
+
+	stored := nodeClaim.DeepCopy()
+	switch {
+	case node != nil && c.unhealthy(node) && age <= restraintClawbackWindow:
+		// Re-break inside the clawback window: the optimistic credit was wrong. Slam every domain shut and back off, and
+		// record the terminal verdict so we never claw back this replacement twice.
+		c.window.SlamShut(domains...)
+		nodeClaim.StatusConditions(status.WithClock(c.clock)).SetTrueWithReason(v1.ConditionTypeRepairClawedBack, "RebrokeInClawbackWindow", "replacement went unhealthy within the clawback window")
+	case !credited && node != nil && c.ready(node) && !c.unhealthy(node):
+		// Optimistic credit on first healthy Ready: widen the domains, once.
+		c.window.Widen(domains...)
+		nodeClaim.StatusConditions(status.WithClock(c.clock)).SetTrueWithReason(v1.ConditionTypeRepairCredited, "ReplacementReady", "replacement came up Ready and healthy")
+	}
+	if !equality.Semantic.DeepEqual(stored, nodeClaim) {
+		if err := c.kubeClient.Status().Patch(ctx, nodeClaim, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsConflict(err) {
+				return reconcile.Result{Requeue: true}, nil
+			}
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+	// Keep watching until the clawback window closes so a later re-break is still caught even if no Node event fires.
+	// After the window, a credited replacement's verdict is final; a re-break is then just a fresh repair candidate.
+	if rem := restraintClawbackWindow - age; rem > 0 && !nodeClaim.StatusConditions().Get(v1.ConditionTypeRepairClawedBack).IsTrue() {
+		return reconcile.Result{RequeueAfter: rem}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+// ready reports whether the replacement's Node is Ready=True.
+func (c *ClawbackController) ready(node *corev1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// unhealthy reports whether the replacement's Node currently matches a RepairPolicy — i.e. it re-broke.
+func (c *ClawbackController) unhealthy(node *corev1.Node) bool {
+	policy, _ := matchRepairPolicy(node, c.cloudProvider.RepairPolicies())
+	return policy != nil
+}
+
+func (c *ClawbackController) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		For(&v1.NodeClaim{}, builder.WithPredicates(nodeclaimutils.IsManagedPredicateFuncs(c.cloudProvider))).
+		// Wake on the replacement Node's health transitions so a re-break inside the window is caught promptly.
+		Watches(&corev1.Node{}, nodeclaimutils.NodeEventHandler(c.kubeClient, c.cloudProvider)).
+		Complete(reconcile.AsReconciler(m.GetClient(), c))
+}

--- a/pkg/controllers/disruption/repair_restraint.go
+++ b/pkg/controllers/disruption/repair_restraint.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Correlated-failure restraint (Node Repair Under Correlated Failure, RFC kubernetes-sigs/karpenter#3031). Per failure
+// domain, repair opens up geometrically while replacements prove out and slams shut when they don't — floored at one
+// probe and capped at a max cooldown, so it always keeps trying but never stampedes. It layers strictly *beneath* the
+// disruption budget, and replaces the placeholder per-NodePool backoff the voluntary-repair POC carried in its score.
+//
+// The dial state lives in a Window shared between two callers: repair's disruption loop READS it (Width/Backoff/Admits)
+// to pace admission, and the clawback controller WRITES it (Widen when a repair replacement proves Ready, SlamShut when
+// one re-breaks inside the clawback window). Because both hold the same instance from different goroutines it is
+// mutex-guarded.
+//
+// Statelessness (invariant): the dials are an optimization, never a correctness requirement. A freshly restarted
+// controller rebuilds an empty Window, and an empty Window cold-starts every domain at width 1 — the most conservative
+// value — so a zero-state restart is always safe.
+const (
+	// restraintWidthFloor is never 0: repair always eventually retries (invariant: pause, don't stop).
+	restraintWidthFloor = 1
+	// restraintCooldownFloor / restraintCooldownCeiling bound the per-domain failure backoff (first cooldown after a
+	// slam, and its exponential cap so repair always eventually retries in a domain).
+	restraintCooldownFloor   = 1 * time.Minute
+	restraintCooldownCeiling = 10 * time.Minute
+	// restraintClawbackWindow is how long an optimistically-credited repair replacement is watched for a re-break before
+	// the credit becomes final. It must exceed the time for a re-inherited fault to resurface (kubelet/agent re-flag
+	// latency), or a systematic false positive slips a widened burst through before clawback fires.
+	restraintClawbackWindow = 5 * time.Minute
+)
+
+// failureDomain is one axis restraint scopes to (NodePool, zone, or policy-condition). A correlated burst collapses into
+// one domain that cold-starts at width 1, so correlation is handled by scoping + cold-start, not a correlation statistic.
+type failureDomain struct {
+	kind  string // "nodepool" | "zone" | "policy"
+	value string
+}
+
+// domainsForNode returns the failure domains a node belongs to: its NodePool, its zone, and one per unhealthy
+// (Status=False) node condition — the condition type is a proxy for the detector, so a bad detector flooding one
+// condition cools that policy domain without touching an unrelated real fault. A node is in several domains at once,
+// and pacing takes the most conservative across them. Reading conditions straight off the node keeps this a pure
+// function of observable state — usable from a Candidate (admission) and from a bare StateNode (in-flight derivation /
+// the clawback controller), with nothing threaded in from repair.
+func domainsForNode(nodePool, zone string, node *corev1.Node) []failureDomain {
+	domains := []failureDomain{
+		{kind: "nodepool", value: nodePool},
+		{kind: "zone", value: zone},
+	}
+	if node != nil {
+		for _, cond := range node.Status.Conditions {
+			if cond.Status == corev1.ConditionFalse {
+				domains = append(domains, failureDomain{kind: "policy", value: string(cond.Type)})
+			}
+		}
+	}
+	return domains
+}
+
+// domainsOf returns the failure domains a candidate belongs to.
+func domainsOf(c *Candidate) []failureDomain {
+	return domainsForNode(c.NodePool.Name, c.zone, c.Node)
+}
+
+// Window is the shared per-domain slow-start + backoff dial ("the window/backoff tracker"). It owns width (how many
+// concurrent unproven repairs a domain allows) and cooldown per failure domain — nothing else. In-flight counts are
+// state-derived by the reader; domain membership is caller-supplied. Empty == every domain at the floor.
+type Window struct {
+	mu        sync.Mutex
+	width     map[failureDomain]int
+	coolUntil map[failureDomain]time.Time
+	failCount map[failureDomain]int
+	now       func() time.Time
+}
+
+func NewWindow(now func() time.Time) *Window {
+	return &Window{
+		width:     map[failureDomain]int{},
+		coolUntil: map[failureDomain]time.Time{},
+		failCount: map[failureDomain]int{},
+		now:       now,
+	}
+}
+
+func (w *Window) widthLocked(d failureDomain) int {
+	if v, ok := w.width[d]; ok && v > restraintWidthFloor {
+		return v
+	}
+	return restraintWidthFloor
+}
+
+// Width is the current window for a domain (>= floor). Reader side.
+func (w *Window) Width(d failureDomain) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.widthLocked(d)
+}
+
+// Backoff is the remaining cooldown for a domain; 0 == ready. Reader side (also the backoff_seconds gauge).
+func (w *Window) Backoff(d failureDomain) time.Duration {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if until, ok := w.coolUntil[d]; ok {
+		if rem := until.Sub(w.now()); rem > 0 {
+			return rem
+		}
+	}
+	return 0
+}
+
+// Admits applies the two combine rules across a candidate's domains, given the current per-domain in-flight count:
+//   - Cooldown — eligible if ANY domain is out of cooldown: a fault in a fresh domain runs right away even when it
+//     shares a backed-off domain with a flood.
+//   - Width — take the min: admit only if EVERY domain has in-flight headroom under its width.
+//
+// Admits is a pure read: it does not mutate the dials (in-flight is derived from cluster state, not counted here), so it
+// is safe to call once per candidate per pass.
+func (w *Window) Admits(domains []failureDomain, inFlight map[failureDomain]int) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	now := w.now()
+	ready := false
+	for _, d := range domains {
+		if until, ok := w.coolUntil[d]; !ok || !now.Before(until) {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return false
+	}
+	for _, d := range domains {
+		if inFlight[d] >= w.widthLocked(d) {
+			return false
+		}
+	}
+	return true
+}
+
+// Widen credits a proven success: double the width in every domain and clear its cooldown (speed up when it works).
+// Writer side — called by the clawback controller when a repair replacement holds Ready.
+func (w *Window) Widen(domains ...failureDomain) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, d := range domains {
+		w.width[d] = w.widthLocked(d) * 2
+		delete(w.coolUntil, d)
+		delete(w.failCount, d)
+	}
+}
+
+// SlamShut records a failure/clawback: reset width to the floor and arm an exponentially-backed-off, capped cooldown so
+// repair pauses in the domain but never stops. Writer side — called by the clawback controller when a repair
+// replacement re-breaks inside the clawback window.
+func (w *Window) SlamShut(domains ...failureDomain) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	now := w.now()
+	for _, d := range domains {
+		w.width[d] = restraintWidthFloor
+		w.failCount[d]++
+		backoff := restraintCooldownFloor << (w.failCount[d] - 1)
+		if backoff > restraintCooldownCeiling || backoff <= 0 {
+			backoff = restraintCooldownCeiling
+		}
+		w.coolUntil[d] = now.Add(backoff)
+	}
+}
+
+// Reset forgets a domain's earned width/cooldown (episode over: the domain has no unhealthy nodes), so a new correlated
+// burst starts slow again — past success is not a predictor of a new correlated failure.
+func (w *Window) Reset(domains ...failureDomain) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, d := range domains {
+		delete(w.width, d)
+		delete(w.coolUntil, d)
+		delete(w.failCount, d)
+	}
+}

--- a/pkg/controllers/disruption/repair_restraint_test.go
+++ b/pkg/controllers/disruption/repair_restraint_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"testing"
+	"time"
+)
+
+// Unit tests for the shared correlated-failure restraint Window. Pure logic — no envtest — so they run even without
+// the API server the Ginkgo suite needs.
+
+func newTestWindow(now *time.Time) *Window {
+	return NewWindow(func() time.Time { return *now })
+}
+
+func TestWindowColdStartsAtFloor(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	d := failureDomain{kind: "zone", value: "us-west-2a"}
+	if got := w.Width(d); got != restraintWidthFloor {
+		t.Fatalf("cold-start Width = %d, want floor %d", got, restraintWidthFloor)
+	}
+	if got := w.Backoff(d); got != 0 {
+		t.Fatalf("cold-start Backoff = %v, want 0", got)
+	}
+	if !w.Admits([]failureDomain{d}, map[failureDomain]int{}) {
+		t.Fatal("expected admit at inFlight=0, width=1")
+	}
+	if w.Admits([]failureDomain{d}, map[failureDomain]int{d: 1}) {
+		t.Fatal("expected NO admit at inFlight=1, width=1 (min-width)")
+	}
+}
+
+func TestWindowWidenDoubles(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	d := failureDomain{kind: "nodepool", value: "gpu"}
+	w.Widen(d)
+	if got := w.Width(d); got != 2 {
+		t.Fatalf("Width after one Widen = %d, want 2", got)
+	}
+	w.Widen(d)
+	if got := w.Width(d); got != 4 {
+		t.Fatalf("Width after two Widen = %d, want 4", got)
+	}
+	if !w.Admits([]failureDomain{d}, map[failureDomain]int{d: 3}) {
+		t.Fatal("expected admit at inFlight=3, width=4")
+	}
+	if w.Admits([]failureDomain{d}, map[failureDomain]int{d: 4}) {
+		t.Fatal("expected NO admit at inFlight=4, width=4")
+	}
+}
+
+func TestWindowSlamShutFloorsAndCools(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	d := failureDomain{kind: "policy", value: "Ready"}
+	w.Widen(d)
+	w.Widen(d) // width 4
+	w.SlamShut(d)
+	if got := w.Width(d); got != restraintWidthFloor {
+		t.Fatalf("Width after SlamShut = %d, want floor %d", got, restraintWidthFloor)
+	}
+	if got := w.Backoff(d); got != restraintCooldownFloor {
+		t.Fatalf("Backoff after first SlamShut = %v, want %v", got, restraintCooldownFloor)
+	}
+	if w.Admits([]failureDomain{d}, map[failureDomain]int{}) {
+		t.Fatal("expected NO admit while in cooldown")
+	}
+	now = now.Add(restraintCooldownFloor)
+	if !w.Admits([]failureDomain{d}, map[failureDomain]int{}) {
+		t.Fatal("expected admit after cooldown elapsed")
+	}
+}
+
+func TestWindowBackoffExponentialCapped(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	d := failureDomain{kind: "zone", value: "z"}
+	// 1m, 2m, 4m, 8m, then capped at 10m.
+	for i, want := range []time.Duration{1, 2, 4, 8, 10, 10} {
+		w.SlamShut(d)
+		if got := w.Backoff(d); got != want*time.Minute {
+			t.Fatalf("SlamShut #%d Backoff = %v, want %v", i+1, got, want*time.Minute)
+		}
+	}
+}
+
+func TestWindowAnyDomainReady(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	cooled := failureDomain{kind: "policy", value: "flood"}
+	fresh := failureDomain{kind: "zone", value: "healthy-zone"}
+	w.SlamShut(cooled)
+	// A candidate in BOTH domains is eligible because ANY domain (fresh) is out of cooldown.
+	if !w.Admits([]failureDomain{cooled, fresh}, map[failureDomain]int{}) {
+		t.Fatal("expected admit: at least one domain (fresh) is ready")
+	}
+	// But if the fresh domain has no width headroom, min-width still blocks.
+	if w.Admits([]failureDomain{cooled, fresh}, map[failureDomain]int{fresh: 1}) {
+		t.Fatal("expected NO admit: fresh domain at its width ceiling (min-width)")
+	}
+}
+
+func TestWindowResetForgetsEarnedState(t *testing.T) {
+	now := time.Now()
+	w := newTestWindow(&now)
+	d := failureDomain{kind: "nodepool", value: "gpu"}
+	w.Widen(d)
+	w.Widen(d) // width 4
+	w.Reset(d)
+	if got := w.Width(d); got != restraintWidthFloor {
+		t.Fatalf("Width after Reset = %d, want floor %d (new episode starts slow)", got, restraintWidthFloor)
+	}
+	if got := w.Backoff(d); got != 0 {
+		t.Fatalf("Backoff after Reset = %v, want 0", got)
+	}
+}

--- a/pkg/controllers/disruption/repair_test.go
+++ b/pkg/controllers/disruption/repair_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Repair", func() {
 	// construction, so specs that override cloudProvider.RepairPolicy must call this again to pick up the new policies.
 	newRepairController := func() {
 		repairController = disruption.NewController(env.Clock, env.Client, prov, cloudProvider, recorder, cluster, queue, clusterCost,
-			disruption.WithMethods(disruption.NewRepair(disruption.MakeConsolidation(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue), cloudProvider.RepairPolicies())))
+			disruption.WithMethods(disruption.NewRepair(disruption.MakeConsolidation(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue), cloudProvider.RepairPolicies(), nil)))
 	}
 
 	BeforeEach(func() {

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	GracefulDisruptionClass = metrics.TerminationModeGraceful // graceful disruption always respects blocking pod PDBs and the do-not-disrupt annotation
-	EventualDisruptionClass = metrics.TerminationModeEventual  // eventual disruption is bounded by a NodePool's TerminationGracePeriod, regardless of blocking pod PDBs and the do-not-disrupt annotation
+	EventualDisruptionClass = metrics.TerminationModeEventual // eventual disruption is bounded by a NodePool's TerminationGracePeriod, regardless of blocking pod PDBs and the do-not-disrupt annotation
 	// RepairDisruptionClass is voluntary node repair. Like graceful, it drains and honors PDBs; unlike graceful, it
 	// ignores do-not-disrupt (repair is not discretionary — it honors the separate do-not-repair veto) and its drain
 	// is bounded by the per-condition RepairPolicy TerminationGracePeriod (0 = forceful), like eventual.

--- a/pkg/controllers/disruption/validation_test.go
+++ b/pkg/controllers/disruption/validation_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func NewMethodsWithRealValidator() []disruption.Method {
-	return disruption.NewMethods(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue, cloudProvider.RepairPolicies())
+	return disruption.NewMethods(env.Clock, cluster, env.Client, prov, cloudProvider, recorder, queue, cloudProvider.RepairPolicies(), nil)
 }
 
 type NopValidator struct{}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -59,6 +59,7 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 	"sigs.k8s.io/karpenter/pkg/scheduling/dynamicresources"
 	"sigs.k8s.io/karpenter/pkg/utils/daemonset"
+	"sigs.k8s.io/karpenter/pkg/utils/launchcontext"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	nodepoolutils "sigs.k8s.io/karpenter/pkg/utils/nodepool"
 	"sigs.k8s.io/karpenter/pkg/utils/pretty"
@@ -69,6 +70,9 @@ import (
 type LaunchOptions struct {
 	RecordPodNomination bool
 	Reason              string
+	// LaunchContext, when its Cause is set, is stamped onto the created NodeClaim as durable launch provenance
+	// (LaunchContextAnnotationKey) so a disruption method can later identify its own replacements from cluster state.
+	LaunchContext launchcontext.Context
 }
 
 // RecordPodNomination causes nominate pod events to be recorded against the node.
@@ -78,6 +82,11 @@ func RecordPodNomination(o *LaunchOptions) {
 
 func WithReason(reason string) func(*LaunchOptions) {
 	return func(o *LaunchOptions) { o.Reason = reason }
+}
+
+// WithLaunchContext stamps launch-time provenance (cause + the NodeClaim it replaces) onto the created NodeClaim.
+func WithLaunchContext(lc launchcontext.Context) func(*LaunchOptions) {
+	return func(o *LaunchOptions) { o.LaunchContext = lc }
 }
 
 // Provisioner waits for enqueued pods, batches them, creates capacity and binds the pods to the capacity.
@@ -162,7 +171,7 @@ func (p *Provisioner) Reconcile(ctx context.Context) (result reconciler.Result, 
 	if len(results.NewNodeClaims) == 0 {
 		return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
 	}
-	if _, err = p.CreateNodeClaims(ctx, results.NewNodeClaims, WithReason(metrics.ProvisionedReason), RecordPodNomination); err != nil {
+	if _, err = p.CreateNodeClaims(ctx, results.NewNodeClaims, WithReason(metrics.ProvisionedReason), WithLaunchContext(launchcontext.Context{Cause: launchcontext.CauseProvisioned}), RecordPodNomination); err != nil {
 		return reconciler.Result{}, err
 	}
 	return reconciler.Result{RequeueAfter: singleton.RequeueImmediately}, nil
@@ -472,6 +481,12 @@ func (p *Provisioner) Create(ctx context.Context, n *scheduler.NodeClaim, opts .
 		return "", err
 	}
 	nodeClaim := n.ToNodeClaim()
+
+	// Stamp durable launch provenance so disruption methods can identify this NodeClaim's origin (and, for a
+	// replacement, what it superseded) from cluster state alone — no in-memory ledger, crash-safe on resync.
+	if options.LaunchContext.Cause != "" {
+		options.LaunchContext.StampOn(nodeClaim)
+	}
 
 	if err := p.kubeClient.Create(ctx, nodeClaim); err != nil {
 		return "", err

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -276,6 +276,17 @@ func (c *Cluster) DeepCopyNodes() StateNodes {
 
 // IsNodeNominated returns true if the given node was expected to have a pod bound to it during a recent scheduling
 // batch
+// GetActiveDisruptions returns every managed node with an in-flight Karpenter disruption of the given reason, read from
+// the durable DisruptionReason condition. It is cluster-wide by design — callers bucket into their own failure domains
+// (a zone or policy domain spans NodePools). Crash-safe: rebuilt from the condition on resync, so it needs no in-memory
+// disruption ledger. Derived from the cached node snapshot, matching how BuildDisruptionBudgetMapping already reads state.
+func (c *Cluster) GetActiveDisruptions(reason v1.DisruptionReason) StateNodes {
+	return lo.Filter(c.DeepCopyNodes(), func(n *StateNode, _ int) bool {
+		r, ok := n.DisruptionReason()
+		return n.Managed() && ok && r == reason
+	})
+}
+
 func (c *Cluster) IsNodeNominated(providerID string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -462,6 +462,21 @@ func (in *StateNode) DisruptionCost() float64 {
 	return cost
 }
 
+// DisruptionReason returns the reason of an in-flight Karpenter-initiated disruption on this node, read from the
+// durable DisruptionReason condition (set when a disruption command is issued, cleared when it completes). ok=false
+// when the node is not currently being disrupted. This is the crash-safe, observable signal for "how many nodes are
+// undergoing an operation" — unlike the in-memory markedForDeletion flag, it is rebuilt from the object on resync.
+func (in *StateNode) DisruptionReason() (v1.DisruptionReason, bool) {
+	if in.NodeClaim == nil {
+		return "", false
+	}
+	cond := in.NodeClaim.StatusConditions().Get(v1.ConditionTypeDisruptionReason)
+	if !cond.IsTrue() {
+		return "", false
+	}
+	return v1.DisruptionReason(cond.Reason), true
+}
+
 func (in *StateNode) MarkedForDeletion() bool {
 	// The Node is marked for deletion if:
 	//  1. The Node has MarkedForDeletion set

--- a/pkg/utils/launchcontext/launchcontext.go
+++ b/pkg/utils/launchcontext/launchcontext.go
@@ -1,0 +1,93 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package launchcontext carries a NodeClaim's launch-time provenance: why it was created and, for a disruption
+// replacement, which NodeClaim it superseded. It is serialized to the karpenter.sh/launch-context ANNOTATION — it is
+// deliberately NOT an apis/v1 CRD field, so it is not subject to CRD field conventions (kube-api-linter, deepcopy-gen)
+// and needs no CRD change. The correlated-failure repair loop reads it to identify its own in-flight replacements —
+// and the failure domain they belong to — from cluster state alone, crash-safe on resync, with no in-memory ledger.
+// (POC: a candidate to promote to a spec.launchContext field later.)
+package launchcontext
+
+import (
+	"encoding/json"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+// Cause is why a NodeClaim was created. It is a superset of the DisruptionReasons (a replacement launched to supersede
+// a disrupted NodeClaim carries that reason) plus Provisioned for a reactively-provisioned NodeClaim. The disruption
+// values deliberately coincide with v1.DisruptionReason so CauseForReason is a plain cast.
+type Cause string
+
+const (
+	// CauseProvisioned — reactive provisioning for pending pods (no NodeClaim replaced).
+	CauseProvisioned Cause = "Provisioned"
+	// CauseUnderutilized/Empty/Drifted — a consolidation/drift replacement.
+	CauseUnderutilized Cause = "Underutilized"
+	CauseEmpty         Cause = "Empty"
+	CauseDrifted       Cause = "Drifted"
+	// CauseUnhealthy — a repair replacement (pre-spun to supersede an unhealthy NodeClaim).
+	CauseUnhealthy Cause = "Unhealthy"
+)
+
+// Context is launch-time provenance for a NodeClaim.
+type Context struct {
+	// Cause is why this NodeClaim was launched.
+	Cause Cause `json:"cause"`
+	// Replaces is the name of the NodeClaim this one was launched to replace. Empty for a reactively provisioned
+	// NodeClaim (Cause=Provisioned).
+	Replaces string `json:"replaces,omitempty"`
+}
+
+// ForReason maps a DisruptionReason to the Cause of a replacement launched to supersede it. The values coincide, so
+// this is a cast — kept as a named function so intent is legible at call sites.
+func ForReason(reason v1.DisruptionReason) Cause {
+	return Cause(reason)
+}
+
+// Marshal renders the Context as the annotation value. A struct of strings never fails to marshal.
+func (c Context) Marshal() string {
+	b, _ := json.Marshal(c)
+	return string(b)
+}
+
+// StampOn writes the launch-context annotation onto an object's annotations. It uses lo.Assign (copy-on-write) rather
+// than mutating the existing map in place: the object's annotation map may be shared, and launches run concurrently
+// (Provisioner.Create parallelizes), so an in-place write races (caught by -race).
+func (c Context) StampOn(o metav1.Object) {
+	o.SetAnnotations(lo.Assign(o.GetAnnotations(), map[string]string{
+		v1.LaunchContextAnnotationKey: c.Marshal(),
+	}))
+}
+
+// Get reads the launch-context annotation off an object. ok is false when the annotation is absent or unparseable (or
+// carries no Cause) — a missing/garbled marker is simply treated as "no provenance", never an error, so a NodeClaim
+// launched before this field existed is handled the same as one launched outside repair.
+func Get(o metav1.Object) (Context, bool) {
+	v, ok := o.GetAnnotations()[v1.LaunchContextAnnotationKey]
+	if !ok {
+		return Context{}, false
+	}
+	var c Context
+	if err := json.Unmarshal([]byte(v), &c); err != nil || c.Cause == "" {
+		return Context{}, false
+	}
+	return c, true
+}

--- a/pkg/utils/launchcontext/launchcontext_test.go
+++ b/pkg/utils/launchcontext/launchcontext_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launchcontext_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/utils/launchcontext"
+)
+
+func TestLaunchContext(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LaunchContext Utils")
+}
+
+var _ = Describe("LaunchContext", func() {
+	It("round-trips a repair replacement through the annotation", func() {
+		nc := &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Name: "gpu-a1b2c"}}
+		want := launchcontext.Context{Cause: launchcontext.CauseUnhealthy, Replaces: "gpu-x9y8z"}
+		want.StampOn(nc)
+
+		Expect(nc.Annotations[v1.LaunchContextAnnotationKey]).To(Equal(`{"cause":"Unhealthy","replaces":"gpu-x9y8z"}`))
+		got, ok := launchcontext.Get(nc)
+		Expect(ok).To(BeTrue())
+		Expect(got).To(Equal(want))
+	})
+
+	It("omits replaces for a reactively provisioned NodeClaim", func() {
+		nc := &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Name: "nc"}}
+		launchcontext.Context{Cause: launchcontext.CauseProvisioned}.StampOn(nc)
+		Expect(nc.Annotations[v1.LaunchContextAnnotationKey]).To(Equal(`{"cause":"Provisioned"}`))
+	})
+
+	It("treats an absent, garbled, or cause-less annotation as no provenance", func() {
+		_, ok := launchcontext.Get(&v1.NodeClaim{})
+		Expect(ok).To(BeFalse())
+
+		garbled := &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1.LaunchContextAnnotationKey: "not json"}}}
+		_, ok = launchcontext.Get(garbled)
+		Expect(ok).To(BeFalse())
+
+		noCause := &v1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1.LaunchContextAnnotationKey: `{"replaces":"x"}`}}}
+		_, ok = launchcontext.Get(noCause)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("maps a DisruptionReason to the coincident Cause", func() {
+		Expect(launchcontext.ForReason(v1.DisruptionReasonUnhealthy)).To(Equal(launchcontext.CauseUnhealthy))
+		Expect(launchcontext.ForReason(v1.DisruptionReasonDrifted)).To(Equal(launchcontext.CauseDrifted))
+	})
+})


### PR DESCRIPTION
Stacked on **[POC 1/4] voluntary repair** (`node-repair-01-voluntary`). Implements Node Repair Under Correlated Failure (F3, kubernetes-sigs/karpenter#3031) as **optimistic credit + clawback**, built on durable state so it needs no in-memory probe ledger and is crash-safe on resync. Independent of terminate-first (2/4) and reason-matching (4/4).

## Mechanism
- **Durable launch provenance** — `karpenter.sh/launch-context` annotation (`LaunchContext{Cause, Replaces}`), stamped on every launch in `Provisioner.Create`. A repair replacement carries *launched-for-repair* + *when* (`CreationTimestamp`) + *where* (its own NodePool/zone labels).
- **Shared per-domain `Window`** (width + cooldown): reader side (`Width`/`Backoff`/`Admits`) paces repair admission; writer side (`Widen`/`SlamShut`/`Reset`) is driven by the clawback controller. Cold-starts at width 1 (conservative on restart).
- **Repair is reader-only** — admission = `Window.Admits` over a **state-derived** in-flight count (`GetActiveDisruptions`, keyed on the durable `DisruptionReason` condition, same walk shape as `BuildDisruptionBudgetMapping`). Removes the placeholder per-NodePool `score` backoff this POC carried (per its TODO).
- **`ClawbackController`** — widens the window the instant a repair replacement holds Ready (optimistic credit); slams it shut + backs off if the replacement re-breaks within the clawback window. Idempotent via durable NodeClaim conditions `RepairCredited` / `RepairClawedBack`; event-driven on Node health.

## Notes
- POC: launch context rides in an annotation (no CRD change); candidate to promote to `spec.launchContext`.
- The clawback window must exceed the re-inherited-fault resurface latency or a systematic false-positive briefly widens before clawback fires — the tuning constraint.
- Tests: unit tests for `Window` + `LaunchContext`; full disruption envtest suite green (pre-existing `Consolidation/DRA` flake aside).